### PR TITLE
docs: architecture diagram + integrations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ inspectable after the fact.
 - **Native artifacts** - DOCX, XLSX, PPTX, and PDF with revisioned editing and
   native renderers.
 
+## Integrations
+
+Work arrives from anywhere and tools stay behind the gateway:
+
+| | |
+|---|---|
+| **Channels in** | Web app, Slack, REST API, schedules - every channel enters through the same run door |
+| **Native** | Slack (mentions, threads, approvals, delivery), GitHub (App auth, clones, PRs) |
+| **Via connectors** | Gmail, Linear, Notion, HubSpot - OAuth handled by the broker, tokens sealed server-side |
+| **Workspace surfaces** | Knowledge base, team memory, skills and playbooks, scheduled automations |
+
 ## Quick Start
 
 Requires [bun](https://bun.sh) and Postgres 16+ with the
@@ -113,11 +124,20 @@ and addresses the host over SSH.
 
 ## Architecture
 
-```
-frontend (Next.js)  ->  backend (Bun + Hono + Postgres)  ->  sandboxes (Daytona/Cube)
-        UI renders the event log        event-sourced runs,          isolated Linux
-        never a live process            trusted tool gateway         workstations
-```
+<p align="center">
+  <img src="docs/media/architecture.svg" alt="useAgent architecture: entry channels feed a self-hosted control plane (Run API, Postgres event log, engine adapters, session UI); adapters spawn an isolated cloud sandbox per thread; every integration crosses the trusted gateway; finished work comes back as editable artifacts" width="100%">
+</p>
+
+Three properties do the heavy lifting:
+
+1. **The engine is a plug.** Claude Code, Codex, OpenCode, and Pi all speak one
+   canonical event contract through the engine adapters - swap engines and your
+   threads, artifacts, and memory stay.
+2. **Every run is an event log.** Postgres is the source of truth: runs survive
+   backend restarts, replay exactly, and stay inspectable after the fact.
+3. **Credentials never enter the sandbox.** The agent's computer is isolated;
+   every integration call crosses the trusted gateway as a typed tool, and the
+   keys live only on your control plane.
 
 | Path | What it owns |
 |---|---|

--- a/docs/media/architecture.svg
+++ b/docs/media/architecture.svg
@@ -1,0 +1,152 @@
+<svg viewBox="0 0 1560 880" xmlns="http://www.w3.org/2000/svg" font-family="-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="a" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#57606a"/>
+    </marker>
+    <marker id="ab" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#0969da"/>
+    </marker>
+  </defs>
+
+  <rect width="1560" height="880" fill="#ffffff"/>
+
+  <!-- ============ LEFT: entry points ============ -->
+  <text x="60" y="120" fill="#57606a" font-size="13" font-weight="600" letter-spacing="1.2">YOUR TEAM</text>
+  <g>
+    <rect x="60" y="136" width="170" height="44" rx="8" fill="#ffffff" stroke="#d0d7de" stroke-width="1.4"/>
+    <text x="145" y="163" fill="#1f2328" font-size="15" text-anchor="middle">Web app</text>
+    <rect x="60" y="192" width="170" height="44" rx="8" fill="#ffffff" stroke="#d0d7de" stroke-width="1.4"/>
+    <text x="145" y="219" fill="#1f2328" font-size="15" text-anchor="middle">Slack</text>
+    <rect x="60" y="248" width="170" height="44" rx="8" fill="#ffffff" stroke="#d0d7de" stroke-width="1.4"/>
+    <text x="145" y="275" fill="#1f2328" font-size="15" text-anchor="middle">API</text>
+    <rect x="60" y="304" width="170" height="44" rx="8" fill="#ffffff" stroke="#d0d7de" stroke-width="1.4"/>
+    <text x="145" y="331" fill="#1f2328" font-size="15" text-anchor="middle">Schedules</text>
+  </g>
+  <g stroke="#8c959f" stroke-width="1.4" fill="none" marker-end="url(#a)">
+    <path d="M 230 158 L 298 200"/>
+    <path d="M 230 214 L 298 210"/>
+    <path d="M 230 270 L 298 222"/>
+    <path d="M 230 326 L 298 232"/>
+  </g>
+
+  <!-- ============ CENTER: control plane ============ -->
+  <rect x="306" y="84" width="620" height="560" rx="12" fill="#f6f8fa" stroke="#d0d7de" stroke-width="1.5"/>
+  <text x="330" y="116" fill="#1f2328" font-size="16" font-weight="700">useAgent control plane</text>
+  <text x="330" y="136" fill="#57606a" font-size="13">self-hosted · one process · Postgres is the source of truth</text>
+
+  <!-- run api -->
+  <rect x="330" y="184" width="200" height="52" rx="8" fill="#ffffff" stroke="#d0d7de" stroke-width="1.4"/>
+  <text x="430" y="206" fill="#1f2328" font-size="15" text-anchor="middle" font-weight="600">Run API</text>
+  <text x="430" y="224" fill="#57606a" font-size="12.5" text-anchor="middle">one door, every channel</text>
+
+  <!-- event log cylinder, right column of the plane -->
+  <g>
+    <path d="M 665 180 L 665 252 A 105 20 0 0 0 875 252 L 875 180" fill="#ffffff" stroke="#d0d7de" stroke-width="1.5"/>
+    <ellipse cx="770" cy="180" rx="105" ry="20" fill="#ffffff" stroke="#d0d7de" stroke-width="1.5"/>
+    <text x="770" y="225" fill="#1f2328" font-size="15" text-anchor="middle" font-weight="600">Event log</text>
+    <text x="770" y="245" fill="#57606a" font-size="12.5" text-anchor="middle">runs · steps · artifacts · memory</text>
+  </g>
+  <path d="M 530 210 L 659 210" stroke="#8c959f" stroke-width="1.4" fill="none" marker-end="url(#a)"/>
+
+  <!-- session ui, left column -->
+  <rect x="330" y="330" width="200" height="52" rx="8" fill="#ffffff" stroke="#d0d7de" stroke-width="1.4"/>
+  <text x="430" y="352" fill="#1f2328" font-size="15" text-anchor="middle" font-weight="600">Session UI</text>
+  <text x="430" y="370" fill="#57606a" font-size="12.5" text-anchor="middle">live SSE · replay · approvals</text>
+  <path d="M 660 262 L 430 262 L 430 324" stroke="#8c959f" stroke-width="1.4" fill="none" marker-end="url(#a)"/>
+  <text x="440" y="292" fill="#57606a" font-size="12.5">replay / live</text>
+
+  <!-- engine adapters directly under the event log -->
+  <rect x="656" y="330" width="230" height="64" rx="8" fill="#ffffff" stroke="#0969da" stroke-width="1.6"/>
+  <text x="771" y="356" fill="#1f2328" font-size="15" text-anchor="middle" font-weight="600">Engine adapters</text>
+  <text x="771" y="376" fill="#0969da" font-size="12.5" text-anchor="middle">one canonical event contract</text>
+  <path d="M 771 330 L 771 292 " stroke="#0969da" stroke-width="1.5" fill="none" marker-end="url(#ab)"/>
+  <text x="786" y="316" fill="#0969da" font-size="12.5">canonical events</text>
+
+  <!-- engine chips -->
+  <g font-size="13.5" text-anchor="middle" fill="#1f2328">
+    <rect x="656" y="422" width="110" height="38" rx="19" fill="#ffffff" stroke="#d0d7de" stroke-width="1.3"/>
+    <text x="711" y="446">Claude Code</text>
+    <rect x="776" y="422" width="110" height="38" rx="19" fill="#ffffff" stroke="#d0d7de" stroke-width="1.3"/>
+    <text x="831" y="446">Codex</text>
+    <rect x="656" y="470" width="110" height="38" rx="19" fill="#ffffff" stroke="#d0d7de" stroke-width="1.3"/>
+    <text x="711" y="494">OpenCode</text>
+    <rect x="776" y="470" width="110" height="38" rx="19" fill="#ffffff" stroke="#d0d7de" stroke-width="1.3"/>
+    <text x="831" y="494">Pi</text>
+  </g>
+
+  <!-- ============ RIGHT: sandbox (dashed = isolation) ============ -->
+  <rect x="986" y="84" width="330" height="330" rx="12" fill="#ffffff" stroke="#d0d7de" stroke-width="1.6" stroke-dasharray="6 5"/>
+  <text x="1010" y="116" fill="#1f2328" font-size="16" font-weight="700">Cloud sandbox</text>
+  <text x="1010" y="136" fill="#57606a" font-size="13">per thread · isolated · no credentials inside</text>
+
+  <rect x="1010" y="160" width="282" height="52" rx="8" fill="#ffffff" stroke="#d0d7de" stroke-width="1.4"/>
+  <text x="1151" y="182" fill="#1f2328" font-size="15" text-anchor="middle" font-weight="600">Engine process</text>
+  <text x="1151" y="200" fill="#57606a" font-size="12.5" text-anchor="middle">the agent you chose, unmodified</text>
+
+  <rect x="1010" y="236" width="282" height="88" rx="8" fill="#ffffff" stroke="#d0d7de" stroke-width="1.4"/>
+  <text x="1151" y="264" fill="#1f2328" font-size="15" text-anchor="middle" font-weight="600">Real computer</text>
+  <text x="1151" y="284" fill="#57606a" font-size="12.5" text-anchor="middle">terminal · browser · files</text>
+  <text x="1151" y="302" fill="#57606a" font-size="12.5" text-anchor="middle">visible desktop (VNC) · recordings</text>
+  <path d="M 1151 212 L 1151 230" stroke="#8c959f" stroke-width="1.4" fill="none" marker-end="url(#a)"/>
+
+  <!-- spawn: adapters -> sandbox, one clean elbow through the gap -->
+  <path d="M 886 362 L 954 362 L 954 186 L 1004 186" stroke="#8c959f" stroke-width="1.4" fill="none" marker-end="url(#a)"/>
+  <text x="946" y="256" fill="#57606a" font-size="12.5" text-anchor="end">spawn</text>
+  <text x="946" y="273" fill="#57606a" font-size="12.5" text-anchor="end">per run</text>
+
+  <!-- ============ BOTTOM: gateway bus ============ -->
+  <rect x="330" y="700" width="986" height="56" rx="10" fill="#ffffff" stroke="#0969da" stroke-width="1.6"/>
+  <text x="823" y="724" fill="#1f2328" font-size="15" text-anchor="middle" font-weight="600">Trusted gateway</text>
+  <text x="823" y="743" fill="#0969da" font-size="12.5" text-anchor="middle">every integration crosses here - credentials never leave it</text>
+
+  <!-- sandbox -> bus -->
+  <path d="M 1151 414 L 1151 694" stroke="#0969da" stroke-width="1.5" fill="none" marker-end="url(#ab)"/>
+  <text x="1163" y="560" fill="#0969da" font-size="12.5">typed tool calls</text>
+  <!-- bus -> plane (results become events) -->
+  <path d="M 560 700 L 560 650" stroke="#8c959f" stroke-width="1.4" fill="none" marker-end="url(#a)"/>
+  <text x="575" y="682" fill="#57606a" font-size="12.5">results back as events</text>
+
+  <!-- integrations under the bus -->
+  <g stroke="#d0d7de" stroke-width="1.2">
+    <line x1="390" y1="756" x2="390" y2="776"/>
+    <line x1="524" y1="756" x2="524" y2="776"/>
+    <line x1="658" y1="756" x2="658" y2="776"/>
+    <line x1="792" y1="756" x2="792" y2="776"/>
+    <line x1="926" y1="756" x2="926" y2="776"/>
+    <line x1="1060" y1="756" x2="1060" y2="776"/>
+    <line x1="1194" y1="756" x2="1194" y2="776"/>
+  </g>
+  <g font-size="13.5" text-anchor="middle" fill="#1f2328">
+    <rect x="330" y="776" width="120" height="38" rx="8" fill="#f6f8fa" stroke="#d0d7de" stroke-width="1.3"/>
+    <text x="390" y="800">Slack</text>
+    <rect x="464" y="776" width="120" height="38" rx="8" fill="#f6f8fa" stroke="#d0d7de" stroke-width="1.3"/>
+    <text x="524" y="800">GitHub</text>
+    <rect x="598" y="776" width="120" height="38" rx="8" fill="#f6f8fa" stroke="#d0d7de" stroke-width="1.3"/>
+    <text x="658" y="800">Gmail</text>
+    <rect x="732" y="776" width="120" height="38" rx="8" fill="#f6f8fa" stroke="#d0d7de" stroke-width="1.3"/>
+    <text x="792" y="800">Linear</text>
+    <rect x="866" y="776" width="120" height="38" rx="8" fill="#f6f8fa" stroke="#d0d7de" stroke-width="1.3"/>
+    <text x="926" y="800">Notion</text>
+    <rect x="1000" y="776" width="120" height="38" rx="8" fill="#f6f8fa" stroke="#d0d7de" stroke-width="1.3"/>
+    <text x="1060" y="800">HubSpot</text>
+    <rect x="1134" y="776" width="120" height="38" rx="8" fill="#f6f8fa" stroke="#d0d7de" stroke-width="1.3"/>
+    <text x="1194" y="800">Knowledge</text>
+  </g>
+
+  <!-- ============ FAR RIGHT: finished work ============ -->
+  <text x="1356" y="544" fill="#57606a" font-size="13" font-weight="600" letter-spacing="1.2">FINISHED WORK</text>
+  <g font-size="13.5" fill="#1f2328">
+    <rect x="1356" y="560" width="150" height="38" rx="8" fill="#ffffff" stroke="#d0d7de" stroke-width="1.3"/>
+    <text x="1431" y="584" text-anchor="middle">Pull requests</text>
+    <rect x="1356" y="608" width="150" height="38" rx="8" fill="#ffffff" stroke="#d0d7de" stroke-width="1.3"/>
+    <text x="1431" y="632" text-anchor="middle">Websites</text>
+    <rect x="1356" y="656" width="150" height="38" rx="8" fill="#ffffff" stroke="#d0d7de" stroke-width="1.3"/>
+    <text x="1431" y="680" text-anchor="middle">Decks · sheets</text>
+    <rect x="1356" y="704" width="150" height="38" rx="8" fill="#ffffff" stroke="#d0d7de" stroke-width="1.3"/>
+    <text x="1431" y="728" text-anchor="middle">Reports · video</text>
+  </g>
+  <path d="M 1316 728 L 1350 728" stroke="#0969da" stroke-width="1.5" fill="none" marker-end="url(#ab)"/>
+
+  <!-- footer -->
+  <text x="60" y="856" fill="#57606a" font-size="13.5">The engine is replaceable. The event log, computer, gateway, and your artifacts are not tied to any of them.</text>
+</svg>


### PR DESCRIPTION
Adds docs/media/architecture.svg (hand-written SVG, flat engineering style - white canvas, GitHub-palette grays, single blue accent, dataflow left to right, gateway drawn as the bus every integration crosses) and replaces the ASCII sketch in the Architecture section with it plus the three load-bearing properties in text. New Integrations section lists what is real today: channels in (web/Slack/API/schedules), native Slack + GitHub, connector-brokered Gmail/Linear/Notion/HubSpot, and the workspace surfaces.