### PR TITLE
fix: gateway announces its public link origin at boot

### DIFF
--- a/backend/src/gateway.ts
+++ b/backend/src/gateway.ts
@@ -18,6 +18,12 @@ if (!Number.isInteger(port) || port < 1 || port > 65_535) {
 }
 
 console.log(`[useagent] sandbox gateway listening on http://localhost:${port}`);
+// Artifact/tool links handed to models are absolute URLs built from
+// FRONTEND_ORIGIN. Announce the resolved origin at boot so a stale env file
+// (e.g. a domain rename that missed gateway.env) is one journal line away
+// instead of a debugging session - links silently pointing at an old domain
+// was a real incident.
+console.log(`[useagent] gateway public links resolve against ${process.env.FRONTEND_ORIGIN?.trim() || "(FRONTEND_ORIGIN unset)"}`);
 
 export const GATEWAY_MAX_REQUEST_BODY_BYTES = 8 * 1024 * 1024;
 


### PR DESCRIPTION
Prevention for a real incident: /etc/useagent/gateway.env kept the pre-rename FRONTEND_ORIGIN after the domain cutover, so the artifact links the gateway hands to models pointed at the old domain (visible only by hovering a link in an agent's Slack reply). The prod env is fixed; this makes the class of drift observable - the gateway now logs the origin it will build public links against, right next to its listen line. Deliberately reads process.env (not the env module) so the GATEWAY_DATABASE_URL restricted-role override keeps running before any config module loads.