### PR TITLE
chore: mirror 0071 fast-deploy marker

### DIFF
--- a/backend/drizzle/0071_slack_stream_progress.sql
+++ b/backend/drizzle/0071_slack_stream_progress.sql
@@ -1,3 +1,4 @@
+-- fast-deploy: expansion-safe
 -- Native Slack streaming progress: how many narration chars the stream has
 -- ACCEPTED. Orders narration appends (each row carries its expected offset) and
 -- lets stopStream append exactly the un-streamed tail of the reply.


### PR DESCRIPTION
Pro PR #6 added `-- fast-deploy: expansion-safe` to 0071_slack_stream_progress.sql in the private repo only. Prod deploys the public repo, so the marker belongs here to take effect - and mirroring keeps the migration file byte-identical across both repos.