### PR TITLE
fix: open workpiece previews in rendered editor

### DIFF
--- a/backend/src/knowledge/gateway/artifact-links.test.ts
+++ b/backend/src/knowledge/gateway/artifact-links.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import type { ArtifactWorkpieceKind } from "@useagent/artifact-workspace";
+import type { ArtifactDescriptor } from "../../artifacts/repo";
+import { env } from "../../env";
+import { absoluteArtifactUrlContent } from "./artifact-links";
+
+function workpieceArtifact(kind: ArtifactWorkpieceKind): ArtifactDescriptor {
+  const extension = kind === "presentation" ? "pptx" : "xlsx";
+  return {
+    id: `artifact-${kind}`,
+    run_id: "run-1",
+    thread_id: "thread-1",
+    name: `result.${extension}`,
+    source_path: `/root/work/result.${extension}`,
+    content_type: "application/octet-stream",
+    size_bytes: 1234,
+    sha256: "abc",
+    created_at: "2026-08-30T00:00:00.000Z",
+    preview_url: `/api/artifacts/artifact-${kind}/content`,
+    download_url: `/api/artifacts/artifact-${kind}/content?download=1`,
+    preview_pdf_url: null,
+    workpiece: {
+      kind,
+      source_version: "abc",
+      state_revision: 0,
+      state_url: `/api/artifacts/artifact-${kind}/workpiece`,
+      export_url: `/api/artifacts/artifact-${kind}/workpiece/export`,
+      exports: [],
+      actions: ["preview", "download", "edit"],
+    },
+  };
+}
+
+describe("absolute artifact links", () => {
+  test.each(["presentation", "spreadsheet"] as const)(
+    "routes a %s preview action to the rendered workpiece and keeps download on source bytes",
+    (kind) => {
+      const artifact = workpieceArtifact(kind);
+
+      expect(absoluteArtifactUrlContent(artifact)).toEqual({
+        preview_url_absolute: `${env.FRONTEND_ORIGIN}/agent/artifacts/${artifact.id}`,
+        download_url_absolute: `${env.FRONTEND_ORIGIN}${artifact.download_url}`,
+      });
+    },
+  );
+});

--- a/backend/src/knowledge/gateway/artifact-links.ts
+++ b/backend/src/knowledge/gateway/artifact-links.ts
@@ -1,7 +1,10 @@
 import type { ArtifactDescriptor } from "../../artifacts/repo";
 import { env } from "../../env";
 
-type ArtifactUrls = Pick<ArtifactDescriptor, "preview_url" | "download_url">;
+type ArtifactUrls = Pick<
+  ArtifactDescriptor,
+  "id" | "preview_url" | "download_url" | "workpiece"
+>;
 
 /**
  * Absolute browser URL for a backend-relative artifact path such as
@@ -14,13 +17,25 @@ export function absoluteArtifactUrl(relativePath: string): string {
 }
 
 /**
+ * Workpieces preview through the rendered editor route. Their immutable source
+ * bytes remain at preview_url, but Office content is intentionally served as an
+ * attachment and therefore cannot be the browser-facing preview action.
+ */
+export function absoluteArtifactPreviewUrl(artifact: ArtifactUrls): string {
+  const previewPath = artifact.workpiece
+    ? `/agent/artifacts/${encodeURIComponent(artifact.id)}`
+    : artifact.preview_url;
+  return absoluteArtifactUrl(previewPath);
+}
+
+/**
  * Absolute-URL companions for tool structuredContent, kept beside the
  * unchanged relative artifact descriptor (the frontend consumes the
  * relative paths).
  */
 export function absoluteArtifactUrlContent(artifact: ArtifactUrls): Record<string, string> {
   return {
-    preview_url_absolute: absoluteArtifactUrl(artifact.preview_url),
+    preview_url_absolute: absoluteArtifactPreviewUrl(artifact),
     download_url_absolute: absoluteArtifactUrl(artifact.download_url),
   };
 }

--- a/backend/src/knowledge/gateway/artifact-tools.ts
+++ b/backend/src/knowledge/gateway/artifact-tools.ts
@@ -5,7 +5,11 @@ import { publishSandboxArtifact } from "../../artifacts/publish";
 import { acceptWorkpieceProposal, proposeWorkpieceEdit } from "../../artifacts/proposals";
 import { toArtifactDescriptor, type ArtifactDescriptor } from "../../artifacts/repo";
 import { isProtectedInjectedSecretPath } from "../../secrets/inject";
-import { absoluteArtifactUrl, absoluteArtifactUrlContent } from "./artifact-links";
+import {
+  absoluteArtifactPreviewUrl,
+  absoluteArtifactUrl,
+  absoluteArtifactUrlContent,
+} from "./artifact-links";
 import type { ToolTokenClaims } from "./token";
 import { WORKPIECE_STATE_INPUT_SCHEMA } from "./workpiece-state-schema";
 
@@ -266,7 +270,7 @@ export async function executeArtifactTool(
       `${verb} ${published.artifact.name} ` +
         `(${published.artifact.size_bytes} bytes) as artifact ${published.artifact.id}.\n` +
         "Preview URL (use exactly as written, never substitute another host): " +
-        `${absoluteArtifactUrl(published.artifact.preview_url)}\n` +
+        `${absoluteArtifactPreviewUrl(published.artifact)}\n` +
         `Download URL (use exactly as written): ${absoluteArtifactUrl(published.artifact.download_url)}`,
       {
         artifact: published.artifact,
@@ -452,7 +456,7 @@ async function workpieceCreateTool(
       `Created ${created.artifact.name} as artifact ${created.artifact.id}. It renders natively and ` +
         `is now open in the user's workspace; Export produces the Office file.${note}\n` +
         "Preview URL (use exactly as written, never substitute another host): " +
-        `${absoluteArtifactUrl(created.artifact.preview_url)}\n` +
+        `${absoluteArtifactPreviewUrl(created.artifact)}\n` +
         `Download URL (use exactly as written): ${absoluteArtifactUrl(created.artifact.download_url)}`,
       {
         artifact: created.artifact,


### PR DESCRIPTION
Routes workpiece Preview links to the rendered artifact editor while preserving immutable source bytes for Download. Covers both presentation and spreadsheet artifacts.\n\nVerified: 10 focused gateway tests and backend TypeScript check.