### PR TITLE
fix: open artifact previews in session workspace

### DIFF
--- a/frontend/components/chat/conversation-quick-wins.test.tsx
+++ b/frontend/components/chat/conversation-quick-wins.test.tsx
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { StoredCanonicalEvent } from "./canonical-timeline";
 import type { ApiRun, RunStatus } from "./types";
+import { WorkspaceOpenProvider } from "./workspace-open-context";
 
 // The canonical-timeline flag is read at module load; flip it on BEFORE importing
 // the conversation so these turns render through the canonical lane.
@@ -168,4 +169,35 @@ test("image artifacts get the click-to-expand affordance; other artifacts do not
   expect(html).toContain('aria-label="Expand screenshot.png"');
   expect(html).toContain("cursor-zoom-in");
   expect(html).not.toContain('aria-label="Expand report.pdf"');
+});
+
+test("workpiece Preview actions open the session workspace and keep Download separate", () => {
+  const turn = makeTurn("run-settled", "completed", [
+    ev("artifact.created", {
+      name: "quarterly-budget.xlsx",
+      artifact: {
+        artifactId: "art-sheet",
+        bytes: 4096,
+        sha256: "b2",
+        contentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      },
+    }),
+  ]);
+  const html = renderToStaticMarkup(
+    <WorkspaceOpenProvider value={() => {}}>
+      <Conversation
+        turns={[turn]}
+        defaultEngine="opencode"
+        defaultModel="claude-sonnet-5"
+        defaultMemoryScope="org"
+        pendingReply={null}
+        onReply={async () => {}}
+      />
+    </WorkspaceOpenProvider>,
+  );
+
+  expect(html).toContain('aria-label="Open quarterly-budget.xlsx in workspace"');
+  expect(html).not.toContain('aria-label="Preview quarterly-budget.xlsx"');
+  expect(html).toContain('href="/api/artifacts/art-sheet/content?download=1"');
+  expect(html).toContain('aria-label="Download quarterly-budget.xlsx"');
 });

--- a/frontend/components/chat/session-view.tsx
+++ b/frontend/components/chat/session-view.tsx
@@ -580,7 +580,7 @@ export function SessionView({
     if (railTab === null) setRailTabOverride("artifacts");
   }, [railTab]);
 
-  const openWorkpiece = useCallback((artifact: TimelineArtifact) => {
+  const openWorkpiece = useCallback((artifact: Pick<TimelineArtifact, "id" | "name">) => {
     setOpenWorkpieces((prev) =>
       prev.some((w) => w.id === artifact.id) ? prev : [...prev, { id: artifact.id, name: artifact.name }],
     );

--- a/frontend/components/chat/timeline-view.tsx
+++ b/frontend/components/chat/timeline-view.tsx
@@ -24,6 +24,7 @@ import { FollowUpRows } from "@/components/chat/follow-up-rows";
 import { SourceChip } from "@/components/chat/source-chip";
 import {
   deriveTurnSources,
+  type TimelineArtifact,
   type TimelineMarker,
   type TimelineNode,
   type TurnSource,
@@ -82,32 +83,44 @@ const TextBurst = memo(function TextBurst({ text }: { text: string }) {
 });
 
 function ArtifactActions({
-  id,
-  name,
-  previewLabel = `Preview ${name}`,
+  artifact,
+  onOpen,
+  previewLabel = `Preview ${artifact.name}`,
 }: {
-  id: string;
-  name: string;
+  artifact: TimelineArtifact;
+  onOpen?: () => void;
   previewLabel?: string;
 }) {
-  const content = `/api/artifacts/${id}/content`;
+  const content = `/api/artifacts/${artifact.id}/content`;
   return (
     <div className="flex shrink-0 items-center gap-1">
-      <a
-        href={content}
-        target="_blank"
-        rel="noreferrer"
-        aria-label={previewLabel}
-        title={previewLabel}
-        className="flex size-8 items-center justify-center rounded-lg text-text-secondary outline-none hover:bg-background-primary-default hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-focus-ring"
-      >
-        <RiExternalLinkLine aria-hidden className="size-4" />
-      </a>
+      {onOpen ? (
+        <button
+          type="button"
+          onClick={onOpen}
+          aria-label={`Open ${artifact.name} in workspace`}
+          title="Open in workspace"
+          className="flex size-8 items-center justify-center rounded-lg text-text-secondary outline-none hover:bg-background-primary-default hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-focus-ring"
+        >
+          <RiExternalLinkLine aria-hidden className="size-4" />
+        </button>
+      ) : (
+        <a
+          href={content}
+          target="_blank"
+          rel="noreferrer"
+          aria-label={previewLabel}
+          title={previewLabel}
+          className="flex size-8 items-center justify-center rounded-lg text-text-secondary outline-none hover:bg-background-primary-default hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-focus-ring"
+        >
+          <RiExternalLinkLine aria-hidden className="size-4" />
+        </a>
+      )}
       <a
         href={`${content}?download=1`}
-        download={name}
-        aria-label={`Download ${name}`}
-        title={`Download ${name}`}
+        download={artifact.name}
+        aria-label={`Download ${artifact.name}`}
+        title={`Download ${artifact.name}`}
         className="flex size-8 items-center justify-center rounded-lg text-text-secondary outline-none hover:bg-background-primary-default hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-focus-ring"
       >
         <RiDownloadLine aria-hidden className="size-4" />
@@ -183,7 +196,12 @@ function ArtifactRow({ node }: { node: Extract<TimelineNode, { kind: "artifact" 
           className="size-4 shrink-0 text-text-tertiary"
         />
       )}
-      {!artifact.destination && <ArtifactActions id={artifact.id} name={artifact.name} />}
+      {!artifact.destination && (
+        <ArtifactActions
+          artifact={artifact}
+          onOpen={canOpen ? () => openWorkpiece?.(artifact) : undefined}
+        />
+      )}
       {expanded && (
         <ExpandedImageDialog
           preview={{
@@ -214,8 +232,13 @@ function FileChangeRow({ node }: { node: Extract<TimelineNode, { kind: "file" }>
       </div>
       {file.diff && (
         <ArtifactActions
-          id={file.diff.artifactId}
-          name={`${name}.diff`}
+          artifact={{
+            id: file.diff.artifactId,
+            name: `${name}.diff`,
+            bytes: file.diff.bytes,
+            sha256: file.diff.sha256,
+            contentType: file.diff.contentType,
+          }}
           previewLabel={`View diff for ${name}`}
         />
       )}

--- a/frontend/components/chat/workspace-open-context.ts
+++ b/frontend/components/chat/workspace-open-context.ts
@@ -6,7 +6,7 @@ import type { TimelineArtifact } from "./timeline";
 /** Opens a canonical workpiece artifact in the session's side-pane Workspace.
  * SessionView provides it; conversation artifact cards consume it. Null outside a
  * session (e.g. the standalone artifacts page), where cards keep card/download. */
-export type OpenWorkpiece = (artifact: TimelineArtifact) => void;
+export type OpenWorkpiece = (artifact: Pick<TimelineArtifact, "id" | "name">) => void;
 
 const WorkspaceOpenContext = createContext<OpenWorkpiece | null>(null);
 

--- a/frontend/components/prompt-kit/markdown.test.tsx
+++ b/frontend/components/prompt-kit/markdown.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
-import { Markdown } from "./markdown";
+import { WorkspaceOpenProvider } from "@/components/chat/workspace-open-context";
+import { artifactPayloadSupportsWorkspace, artifactWorkspaceTarget, Markdown } from "./markdown";
 
 describe("Markdown links", () => {
   test("renders downloadable artifacts as compact typed chips", () => {
@@ -21,5 +22,74 @@ describe("Markdown links", () => {
 
     expect(html).toContain('href="https://useagent.org/docs/"');
     expect(html).not.toContain("rounded-full");
+  });
+
+  test("recognizes old and current workpiece preview URLs", () => {
+    expect(
+      artifactWorkspaceTarget(
+        "/api/artifacts/deck%201/content",
+        "Preview the Quarterly deck",
+        "https://app.useagent.org",
+      ),
+    ).toEqual({ id: "deck 1", name: "Quarterly deck" });
+    expect(
+      artifactWorkspaceTarget(
+        "https://app.useagent.org/agent/artifacts/sheet-1",
+        "Preview Budget.xlsx",
+        "https://app.useagent.org",
+      ),
+    ).toEqual({ id: "sheet-1", name: "Budget.xlsx" });
+    expect(
+      artifactWorkspaceTarget(
+        "/api/artifacts/deck-1/content?download=1",
+        "Preview deck",
+        "https://app.useagent.org",
+      ),
+    ).toBeNull();
+    expect(
+      artifactWorkspaceTarget(
+        "https://evil.example/api/artifacts/deck-1/content",
+        "Preview deck",
+        "https://app.useagent.org",
+      ),
+    ).toBeNull();
+  });
+
+  test("does not speculate about workspace support before metadata resolves", () => {
+    const html = renderToStaticMarkup(
+      <WorkspaceOpenProvider value={() => {}}>
+        <Markdown>{"[Preview the deck](/api/artifacts/deck-1/content)"}</Markdown>
+      </WorkspaceOpenProvider>,
+    );
+
+    expect(html).toContain('href="/api/artifacts/deck-1/content"');
+    expect(html).toContain('target="_blank"');
+  });
+
+  test("uses authoritative artifact metadata for workspace eligibility", () => {
+    expect(
+      artifactPayloadSupportsWorkspace({ artifact: { workpiece: { kind: "presentation" } } }),
+    ).toBe(true);
+    expect(
+      artifactPayloadSupportsWorkspace({
+        artifact: { workpiece: null, preview_pdf_url: "/preview" },
+      }),
+    ).toBe(true);
+    expect(
+      artifactPayloadSupportsWorkspace({
+        artifact: { content_type: "video/mp4", workpiece: null, preview_pdf_url: null },
+      }),
+    ).toBe(false);
+  });
+
+  test("keeps artifact Download chips as download links inside a session", () => {
+    const html = renderToStaticMarkup(
+      <WorkspaceOpenProvider value={() => {}}>
+        <Markdown>{"[Download the deck](/api/artifacts/deck-1/content?download=1)"}</Markdown>
+      </WorkspaceOpenProvider>,
+    );
+
+    expect(html).toContain('href="/api/artifacts/deck-1/content?download=1"');
+    expect(html).toContain('target="_blank"');
   });
 });

--- a/frontend/components/prompt-kit/markdown.tsx
+++ b/frontend/components/prompt-kit/markdown.tsx
@@ -3,13 +3,15 @@
 // (`bg-primary-foreground`) → `bg-background-secondary-default`. Block-splitting +
 // per-block memoization keep re-renders cheap while text streams in.
 
-import { cx } from "@/utils/cx";
 import { marked } from "marked";
-import { memo, useId, useMemo } from "react";
+import { memo, useEffect, useId, useMemo, useState } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import { CodeBlock } from "@/components/ai/code-block";
+import { type OpenWorkpiece, useOpenWorkpiece } from "@/components/chat/workspace-open-context";
+import { backendFetch } from "@/lib/backend-fetch";
+import { cx } from "@/utils/cx";
 
 export type MarkdownProps = {
   children: string;
@@ -27,6 +29,120 @@ function extractLanguage(className?: string): string {
   if (!className) return "plaintext";
   const match = className.match(/language-(\w+)/);
   return match ? match[1] : "plaintext";
+}
+
+type WorkspaceEligibility = "loading" | "raw" | "workspace";
+
+export function artifactPayloadSupportsWorkspace(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const artifact = (value as { artifact?: unknown }).artifact;
+  if (!artifact || typeof artifact !== "object" || Array.isArray(artifact)) return false;
+  const descriptor = artifact as { workpiece?: unknown; preview_pdf_url?: unknown };
+  return (
+    (descriptor.workpiece !== null &&
+      typeof descriptor.workpiece === "object" &&
+      !Array.isArray(descriptor.workpiece)) ||
+    (typeof descriptor.preview_pdf_url === "string" && descriptor.preview_pdf_url.length > 0)
+  );
+}
+
+function ArtifactMarkdownChip({
+  url,
+  label,
+  tone,
+  initial,
+  openWorkpiece,
+}: {
+  readonly url: string;
+  readonly label: string;
+  readonly tone: string;
+  readonly initial: string;
+  readonly openWorkpiece: OpenWorkpiece;
+}) {
+  const [origin, setOrigin] = useState<string | null>(null);
+  const [eligibility, setEligibility] = useState<WorkspaceEligibility>("loading");
+  useEffect(() => setOrigin(window.location.origin), []);
+  const previewTarget = useMemo(
+    () => (origin ? artifactWorkspaceTarget(url, label, origin) : null),
+    [label, origin, url],
+  );
+
+  useEffect(() => {
+    if (!previewTarget) {
+      setEligibility("raw");
+      return;
+    }
+    const controller = new AbortController();
+    setEligibility("loading");
+    void (async () => {
+      try {
+        const response = await backendFetch(
+          `/api/artifacts/${encodeURIComponent(previewTarget.id)}`,
+          { cache: "no-store", signal: controller.signal },
+        );
+        if (!response.ok) {
+          setEligibility("raw");
+          return;
+        }
+        setEligibility(
+          artifactPayloadSupportsWorkspace(await response.json()) ? "workspace" : "raw",
+        );
+      } catch {
+        if (!controller.signal.aborted) setEligibility("raw");
+      }
+    })();
+    return () => controller.abort();
+  }, [previewTarget]);
+
+  const chipClassName =
+    "mx-0.5 inline-flex translate-y-[-1px] items-center gap-1.5 rounded-full bg-background-secondary-default py-0.5 pl-1 pr-2 align-middle text-caption-1-medium text-text-primary no-underline transition-colors hover:bg-background-secondary-hover";
+  const content = (
+    <>
+      <span
+        aria-hidden
+        className={`flex size-4 items-center justify-center rounded-full text-[9px] font-semibold leading-none text-white ${tone}`}
+      >
+        {initial}
+      </span>
+      <span className="max-w-56 truncate">{label}</span>
+      <span aria-hidden className="text-text-tertiary">
+        ↗
+      </span>
+    </>
+  );
+
+  if (previewTarget && eligibility === "workspace") {
+    return (
+      <button
+        type="button"
+        data-chip
+        onClick={() => openWorkpiece(previewTarget)}
+        aria-label={`Open ${previewTarget.name} in workspace`}
+        className={chipClassName}
+      >
+        {content}
+      </button>
+    );
+  }
+  if (previewTarget && eligibility === "loading") {
+    return (
+      <button
+        type="button"
+        data-chip
+        disabled
+        aria-busy="true"
+        aria-label={`Loading preview for ${previewTarget.name}`}
+        className={chipClassName}
+      >
+        {content}
+      </button>
+    );
+  }
+  return (
+    <a data-chip href={url} target="_blank" rel="noreferrer" className={chipClassName}>
+      {content}
+    </a>
+  );
 }
 
 const INITIAL_COMPONENTS: Partial<Components> = {
@@ -81,9 +197,7 @@ const INITIAL_COMPONENTS: Partial<Components> = {
     return <thead className="bg-background-secondary-default">{children}</thead>;
   },
   tr: function TrComponent({ children }) {
-    return (
-      <tr className="border-border-button-default border-b">{children}</tr>
-    );
+    return <tr className="border-border-button-default border-b">{children}</tr>;
   },
   th: function ThComponent({ children }) {
     return (
@@ -93,24 +207,46 @@ const INITIAL_COMPONENTS: Partial<Components> = {
     );
   },
   td: function TdComponent({ children }) {
-    return (
-      <td className="text-text-primary px-3 py-2 align-top">{children}</td>
-    );
+    return <td className="text-text-primary px-3 py-2 align-top">{children}</td>;
   },
   a: function AnchorComponent({ href, children }) {
     const url = typeof href === "string" ? href : "";
+    const openWorkpiece = useOpenWorkpiece();
     // Artifact/media links render as dense source chips (type badge + label +
     // arrow), matching the retrieval-chip grammar; ordinary links stay links.
-    const isArtifact = /\/api\/artifacts\//.test(url);
-    const ext = (url.match(/\.(mp4|webm|pdf|docx|xlsx|pptx|csv|png|jpg|zip)(?:\?|$)/i)?.[1] ?? "").toUpperCase();
+    const isArtifact = /\/(?:api|agent)\/artifacts\//.test(url);
+    const ext = (
+      url.match(/\.(mp4|webm|pdf|docx|xlsx|pptx|csv|png|jpg|zip)(?:\?|$)/i)?.[1] ?? ""
+    ).toUpperCase();
     if (isArtifact || ext) {
-      const label = typeof children === "string" ? children : Array.isArray(children) ? children.join("") : "Open";
+      const label =
+        typeof children === "string"
+          ? children
+          : Array.isArray(children)
+            ? children.join("")
+            : "Open";
       const tone =
-        ext === "PDF" ? "bg-red-500" :
-        ext === "CSV" || ext === "XLSX" ? "bg-green-600" :
-        ext === "MP4" || ext === "WEBM" ? "bg-purple-500" :
-        ext === "PPTX" ? "bg-orange-500" : "bg-blue-500";
+        ext === "PDF"
+          ? "bg-red-500"
+          : ext === "CSV" || ext === "XLSX"
+            ? "bg-green-600"
+            : ext === "MP4" || ext === "WEBM"
+              ? "bg-purple-500"
+              : ext === "PPTX"
+                ? "bg-orange-500"
+                : "bg-blue-500";
       const initial = (label.trim().charAt(0) || "F").toUpperCase();
+      if (openWorkpiece) {
+        return (
+          <ArtifactMarkdownChip
+            url={url}
+            label={label}
+            tone={tone}
+            initial={initial}
+            openWorkpiece={openWorkpiece}
+          />
+        );
+      }
       return (
         <a
           data-chip
@@ -119,11 +255,16 @@ const INITIAL_COMPONENTS: Partial<Components> = {
           rel="noreferrer"
           className="mx-0.5 inline-flex translate-y-[-1px] items-center gap-1.5 rounded-full bg-background-secondary-default py-0.5 pl-1 pr-2 align-middle text-caption-1-medium text-text-primary no-underline transition-colors hover:bg-background-secondary-hover"
         >
-          <span aria-hidden className={`flex size-4 items-center justify-center rounded-full text-[9px] font-semibold leading-none text-white ${tone}`}>
+          <span
+            aria-hidden
+            className={`flex size-4 items-center justify-center rounded-full text-[9px] font-semibold leading-none text-white ${tone}`}
+          >
             {initial}
           </span>
           <span className="max-w-56 truncate">{label}</span>
-          <span aria-hidden className="text-text-tertiary">↗</span>
+          <span aria-hidden className="text-text-tertiary">
+            ↗
+          </span>
         </a>
       );
     }
@@ -144,6 +285,37 @@ const INITIAL_COMPONENTS: Partial<Components> = {
     return <hr className="border-border-button-default my-4" />;
   },
 };
+
+export function artifactWorkspaceTarget(
+  value: string,
+  label: string,
+  origin: string,
+): { readonly id: string; readonly name: string } | null {
+  if (!/^preview\b/i.test(label.trim())) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(value, origin);
+  } catch {
+    return null;
+  }
+  if (parsed.origin !== origin) return null;
+  if (parsed.searchParams.get("download") === "1") return null;
+  const pathname = parsed.pathname;
+  const match = /^\/(?:api\/artifacts\/([^/]+)\/content|agent\/artifacts\/([^/]+))$/.exec(pathname);
+  const encodedId = match?.[1] ?? match?.[2];
+  if (!encodedId) return null;
+  try {
+    const id = decodeURIComponent(encodedId);
+    const name =
+      label
+        .trim()
+        .replace(/^preview\s+(?:the\s+)?/i, "")
+        .trim() || "Artifact";
+    return { id, name };
+  } catch {
+    return null;
+  }
+}
 
 // Flow-element prose styling shared by EVERY Markdown consumer. The
 // foundation ships no @tailwindcss/typography, and Tailwind preflight strips
@@ -177,10 +349,7 @@ const MemoizedMarkdownBlock = memo(
     components?: Partial<Components>;
   }) {
     return (
-      <ReactMarkdown
-        remarkPlugins={[remarkGfm, remarkBreaks]}
-        components={components}
-      >
+      <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} components={components}>
         {content}
       </ReactMarkdown>
     );


### PR DESCRIPTION
Exact shared implementation from Pro: metadata-confirmed PPTX, spreadsheets, documents, and rendered PDFs open in the session Workspace—including old Preview links—while Download, media, foreign URLs, and outside-session links remain unchanged.\n\nVerification: exact six-file hash parity with Pro; 12 focused tests; frontend TypeScript; Biome.