### PR TITLE
fix: recognize open-preview artifact labels

### DIFF
--- a/frontend/components/prompt-kit/markdown.test.tsx
+++ b/frontend/components/prompt-kit/markdown.test.tsx
@@ -41,6 +41,13 @@ describe("Markdown links", () => {
     ).toEqual({ id: "sheet-1", name: "Budget.xlsx" });
     expect(
       artifactWorkspaceTarget(
+        "https://app.useagent.org/agent/artifacts/deck-1",
+        "Open presentation preview",
+        "https://app.useagent.org",
+      ),
+    ).toEqual({ id: "deck-1", name: "presentation" });
+    expect(
+      artifactWorkspaceTarget(
         "/api/artifacts/deck-1/content?download=1",
         "Preview deck",
         "https://app.useagent.org",

--- a/frontend/components/prompt-kit/markdown.tsx
+++ b/frontend/components/prompt-kit/markdown.tsx
@@ -291,7 +291,8 @@ export function artifactWorkspaceTarget(
   label: string,
   origin: string,
 ): { readonly id: string; readonly name: string } | null {
-  if (!/^preview\b/i.test(label.trim())) return null;
+  const normalizedLabel = label.trim();
+  if (!/^(?:preview\b|open\b.*\bpreview\b)/i.test(normalizedLabel)) return null;
   let parsed: URL;
   try {
     parsed = new URL(value, origin);
@@ -307,9 +308,10 @@ export function artifactWorkspaceTarget(
   try {
     const id = decodeURIComponent(encodedId);
     const name =
-      label
-        .trim()
+      normalizedLabel
         .replace(/^preview\s+(?:the\s+)?/i, "")
+        .replace(/^open\s+/i, "")
+        .replace(/\s+preview$/i, "")
         .trim() || "Artifact";
     return { id, name };
   } catch {


### PR DESCRIPTION
Exact Pro compatibility follow-up for the production “Open presentation preview” label form. Metadata gating and media/foreign/download behavior remain unchanged.\n\nVerified: identical two-file patch, 6 focused tests, frontend TypeScript, Biome.