### PR TITLE
Refine typography: Inter primary UI font + antialiasing + denser sidebar

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -28,15 +28,20 @@
   --font-mono-source: var(--font-mono);
 }
 
-/* Native-first base type. On Apple platforms this renders in SF Pro, on Windows
- * in Segoe UI, and everywhere else it falls through to the loaded Inter web font
- * (--font-sans, whose first entry is next/font's Inter) before the generic
- * sans-serif floor. system-ui/Roboto are deliberately omitted so Android/Linux
- * land on Inter rather than Roboto/Cantarell. This un-layered `html` rule wins
- * over Tailwind's preflight and the `@layer base` html block (un-layered beats
- * layered), so it sets the applied font-family without needing !important. */
+/* Inter-first base type. The loaded Inter web font (--font-sans, whose first
+ * entry is next/font's Inter) leads on EVERY platform - including Apple, where
+ * we intentionally render Inter instead of SF Pro so the product matches its
+ * reference typography (crisp, even, geometric UI text). Native faces
+ * (-apple-system / Segoe UI) are the fallback only while the web font loads or
+ * if it fails. Grayscale antialiasing keeps Inter light and sharp rather than
+ * the heavier subpixel default. This un-layered `html` rule wins over Tailwind's
+ * preflight and the `@layer base` html block (un-layered beats layered), so it
+ * sets the applied font-family without needing !important. */
 html {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", var(--font-sans), sans-serif;
+  font-family: var(--font-sans), -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
 }
 
 /* Default-palette bridge for styles/theme.css.
@@ -3747,12 +3752,12 @@ html {
  *   text-display-sm  ~24px, in-header page titles (runs, settings, knowledge)
  * ========================================================================= */
 @utility font-display {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", var(--font-display), var(--font-sans), sans-serif;
+  font-family: var(--font-display), var(--font-sans), -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-feature-settings: 'cv11', 'ss01', 'liga', 'calt';
 }
 
 @utility text-display-lg {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", var(--font-display), var(--font-sans), sans-serif;
+  font-family: var(--font-display), var(--font-sans), -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-feature-settings: 'cv11', 'ss01', 'liga', 'calt';
   font-size: 2.5rem; /* 40px */
   line-height: 1.05;
@@ -3761,7 +3766,7 @@ html {
 }
 
 @utility text-display-md {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", var(--font-display), var(--font-sans), sans-serif;
+  font-family: var(--font-display), var(--font-sans), -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-feature-settings: 'cv11', 'ss01', 'liga', 'calt';
   font-size: 2rem; /* 32px */
   line-height: 1.1;
@@ -3770,7 +3775,7 @@ html {
 }
 
 @utility text-display-sm {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", var(--font-display), var(--font-sans), sans-serif;
+  font-family: var(--font-display), var(--font-sans), -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-feature-settings: 'cv11', 'ss01', 'liga', 'calt';
   font-size: 1.5rem; /* 24px */
   line-height: 1.15;
@@ -3779,7 +3784,7 @@ html {
 }
 
 @utility text-display-xs {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", var(--font-display), var(--font-sans), sans-serif;
+  font-family: var(--font-display), var(--font-sans), -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-feature-settings: 'cv11', 'ss01', 'liga', 'calt';
   font-size: 1.25rem; /* 20px */
   line-height: 1.2;

--- a/frontend/components/shell/sidebar-nav.tsx
+++ b/frontend/components/shell/sidebar-nav.tsx
@@ -88,7 +88,7 @@ export function SidebarNavItem({
       href={href}
       aria-current={active ? "page" : undefined}
       className={cx(
-        "flex items-center gap-2 rounded-2lg px-2.5 py-1.5 text-body-medium transition-colors",
+        "flex items-center gap-2 rounded-2lg px-2.5 py-1.5 text-body-2-medium transition-colors",
         active
           ? "bg-linear-to-b from-accent-500 to-accent-600 text-white shadow-nav-selected"
           : "text-text-secondary hover:bg-background-secondary-hover hover:text-text-primary",


### PR DESCRIPTION
Switches the product's primary UI typeface to **Inter** (and Inter Tight for display) on every platform, including Apple where the base rule previously rendered SF Pro.

**Changes**
- `app/globals.css`: base `html` font stack now leads with `var(--font-sans)` (Inter) / display ramp leads with `var(--font-display)` (Inter Tight); native faces become the fallback while the web font loads. Adds `-webkit-font-smoothing: antialiased` + `-moz-osx-font-smoothing: grayscale` + `optimizeLegibility` so light-theme text stays crisp.
- `components/shell/sidebar-nav.tsx`: nav items move to the 13px `body-2` scale for a tighter, denser rail.

Intentional reversal of the prior native-first decision so the UI matches our reference typography. Verified rendering in a running build (light + dark).