### PR TITLE
Refine AI-kit component fidelity + soften light-theme text

### DIFF
--- a/frontend/components/ai/approval-card.tsx
+++ b/frontend/components/ai/approval-card.tsx
@@ -68,7 +68,7 @@ export function ApprovalCard({
           </button>
         </div>
 
-        <div className="mt-3 flex flex-col gap-0.5">
+        <div className="mt-2.5 flex flex-col gap-1">
           {options.map((option, index) => {
             const active = selected === index && !customActive;
             return (
@@ -100,7 +100,7 @@ export function ApprovalCard({
                 <span className="min-w-0">
                   <span
                     className={cx(
-                      "block text-body-2-medium transition-colors duration-200",
+                      "block text-body-2-regular transition-colors duration-200",
                       active ? "text-text-primary" : "text-text-secondary",
                     )}
                   >

--- a/frontend/components/ai/chat-composer.tsx
+++ b/frontend/components/ai/chat-composer.tsx
@@ -10,6 +10,23 @@ const chatActions = [
   { id: "more", label: "More", Icon: RiMoreLine },
 ] as const;
 
+// Each agent step renders as a two-line unit: a header row (bold step label +
+// muted tool name + run duration) over a full result sentence.
+const steps = [
+  {
+    label: "Sales History",
+    tool: "Flavor Data",
+    duration: "4s",
+    result: "Pulled 3 summers of mint chip sales for comparison.",
+  },
+  {
+    label: "Comparison",
+    tool: "Trend Detection",
+    duration: "2s",
+    result: "Mint chip is up 12% with stronger weekend peaks.",
+  },
+] as const;
+
 interface ChatMessage {
   readonly id: string;
   readonly text: string;
@@ -68,15 +85,17 @@ export function ChatComposer() {
             {message.text}
           </div>
         ))}
-        <div className="space-y-1 text-body-2-regular text-text-secondary">
-          <p>
-            <strong className="text-text-primary">Sales History</strong> pulled three summers of
-            flavor data.
-          </p>
-          <p>
-            <strong className="text-text-primary">Comparison</strong> found stronger weekend
-            peaks.
-          </p>
+        <div className="flex flex-col gap-3">
+          {steps.map((step) => (
+            <div key={step.label} className="flex flex-col gap-1.5">
+              <div className="flex items-center gap-1.5">
+                <span className="text-caption-1-medium text-text-primary">{step.label}</span>
+                <span className="text-caption-1-regular text-text-secondary">{step.tool}</span>
+                <span className="text-caption-1-regular text-text-primary">for {step.duration}</span>
+              </div>
+              <p className="text-body-2-regular text-text-primary">{step.result}</p>
+            </div>
+          ))}
         </div>
       </div>
 

--- a/frontend/components/ai/code-block.tsx
+++ b/frontend/components/ai/code-block.tsx
@@ -71,7 +71,7 @@ function CopyButton({ code }: { code: string }) {
           window.setTimeout(() => setCopied(false), 1400);
         });
       }}
-      className="text-text-tertiary hover:bg-background-secondary-hover hover:text-text-primary flex h-6 items-center gap-1 rounded-md px-1.5 text-caption-1-medium transition-colors"
+      className="text-text-tertiary hover:bg-background-secondary-hover hover:text-text-primary flex h-6 items-center gap-1 rounded-[6px] px-1.5 text-caption-1-medium transition-colors"
     >
       {copied ? (
         <RiCheckLine className="text-lime-600 size-3.5" aria-hidden />
@@ -133,10 +133,10 @@ export function CodeBlock({
       )}
     >
       {/* Header bar */}
-      <div className="border-border-button-default bg-background-primary-default flex items-center justify-between border-b px-3 py-1.5">
+      <div className="border-border-button-default bg-background-primary-default flex items-center justify-between border-b h-11 px-4">
         <span className="flex items-baseline gap-2 truncate">
           {filename && (
-            <span className="text-text-primary truncate font-mono text-[12px] font-medium">
+            <span className="text-text-primary truncate font-mono">
               {filename}
             </span>
           )}
@@ -149,7 +149,7 @@ export function CodeBlock({
 
       {/* Body */}
       {trimmed ? (
-        <div className="ai-code-surface overflow-x-auto text-[12.5px] leading-[1.7]">
+        <div className="ai-code-surface overflow-x-auto text-[12.5px] leading-[1.65]">
           {html ? (
             <div dangerouslySetInnerHTML={{ __html: html }} />
           ) : (

--- a/frontend/components/ai/context-card.tsx
+++ b/frontend/components/ai/context-card.tsx
@@ -91,7 +91,7 @@ export function ContextCard({
   return (
     <article
       className={cx(
-        "overflow-hidden rounded-xl border border-border-button-default bg-background-primary-default shadow-card transition-colors hover:border-border-button-hover",
+        "overflow-hidden rounded-2xl border border-border-button-default bg-background-primary-default shadow-card transition-colors hover:border-border-button-hover",
         className,
       )}
     >
@@ -111,7 +111,7 @@ export function ContextCard({
       </div>
       <div
         className={cx(
-          "line-clamp-2 px-3 text-body-2-regular text-text-secondary",
+          "line-clamp-2 px-3 text-body-2-regular leading-relaxed text-text-secondary",
           source ? "pt-2 pb-1" : "py-2",
         )}
       >
@@ -142,7 +142,7 @@ export function ContextCardStack({
   return (
     <div className={cx("flex flex-col gap-2", className)}>
       <div className="flex items-center gap-2 px-0.5">
-        <span className="text-body-2-medium text-text-primary">{label}</span>
+        <span className="text-body-2-semibold text-text-primary">{label}</span>
         <Chip color="gray">
           {count}
         </Chip>

--- a/frontend/components/ai/filter-table.tsx
+++ b/frontend/components/ai/filter-table.tsx
@@ -100,9 +100,9 @@ export function FilterTable({
         aria-pressed={on}
         onClick={() => setActive(id)}
         className={cx(
-          "flex h-7 shrink-0 items-center gap-1.5 rounded-full px-2.5 text-caption-1-medium transition-colors duration-200",
+          "flex h-6.5 shrink-0 items-center gap-1.5 rounded-full px-2.5 text-caption-1-medium transition-colors duration-200",
           on
-            ? "bg-background-primary-default text-text-primary shadow-sm ring-border-button-default ring-1"
+            ? "bg-background-primary-default text-text-primary shadow-sm"
             : "text-text-secondary hover:bg-background-primary-hover",
         )}
       >
@@ -110,7 +110,7 @@ export function FilterTable({
         {label}
         <span
           className={cx(
-            "rounded px-1 text-[10.5px] tabular-nums",
+            "rounded-[4px] px-1 text-[10.5px] tabular-nums",
             on ? "bg-background-secondary-default text-text-secondary" : "text-text-tertiary",
           )}
         >
@@ -140,7 +140,7 @@ export function FilterTable({
           <div
             className={cx(
               COLS,
-              "border-border-button-default text-caption-1-medium text-text-tertiary border-b px-3 py-2",
+              "border-border-button-default text-body-2-medium text-text-secondary border-b px-3 py-2",
             )}
           >
             <span>{h.name}</span>
@@ -155,7 +155,7 @@ export function FilterTable({
                 key={`${row.name}-${i}`}
                 className={cx(
                   COLS,
-                  "border-border-button-default hover:bg-background-primary-hover items-center border-b px-3 py-2 text-caption-1-regular transition-colors duration-100 last:border-0",
+                  "border-border-button-default hover:bg-background-primary-hover items-center border-b px-3 py-2 text-body-2-regular transition-colors duration-100 last:border-0",
                 )}
               >
                 <span className="text-text-primary truncate font-medium">
@@ -166,7 +166,7 @@ export function FilterTable({
                   {status && (
                     <span
                       className={cx(
-                        "inline-flex h-5 items-center rounded-md px-1.5 text-[11px] font-medium",
+                        "inline-flex h-[23px] items-center rounded-lg border border-border-button-default px-[7px] text-body-2-medium",
                         tone[status.tone].pill,
                       )}
                     >

--- a/frontend/components/ai/fine-tune-card.tsx
+++ b/frontend/components/ai/fine-tune-card.tsx
@@ -45,7 +45,7 @@ export function FineTuneCard() {
     layout !== "Row" || width !== 324 || height !== 96 || radius !== 28 || opacity !== 100;
 
   return (
-    <div className="w-full max-w-xs rounded-2xl border border-border-button-default bg-background-primary-default shadow-md">
+    <div className="w-full max-w-60 rounded-2xl border border-border-button-default bg-background-primary-default shadow-card">
       <div className="flex items-center justify-between border-b border-border-button-default px-3 py-2.5">
         <span className="text-body-2-medium text-text-primary">Flavor card</span>
         <span className={`text-caption-1-regular ${edited ? "text-lime-600" : "text-accent-500"}`}>

--- a/frontend/components/ai/recommendation-card.tsx
+++ b/frontend/components/ai/recommendation-card.tsx
@@ -1,15 +1,13 @@
 import type { ReactNode } from "react";
-import { Chip } from "@/components/base/badges/chip";
 import { Button } from "@/components/base/buttons/button";
 import { cx } from "@/utils/cx";
 
 /**
- * Suggestion card — a titled recommendation with a confidence pill and an
- * Accept / Alternatives footer. Ported from the AI library's RecommendationCard
- * onto our tokens (Badge + Button).
+ * Suggestion card - a titled recommendation with a confidence meter and an
+ * Accept / Alternatives footer. Composed from our Button primitive and tokens.
  *
- * The confidence Badge pairs a colored dot with a label:
- *   high → green · medium → yellow · low → gray.
+ * Confidence renders as a 3-bar signal meter (high = 3 filled, medium = 2, low
+ * = 1) beside a label.
  *
  * Handlers are passed in by the (client) consumer; this component owns no
  * state, so it stays a plain composable leaf.
@@ -17,25 +15,10 @@ import { cx } from "@/utils/cx";
 
 type Confidence = "high" | "medium" | "low";
 
-const confidenceMeta: Record<
-  Confidence,
-  { color: "lime" | "yellow" | "gray"; dot: string; label: string }
-> = {
-  high: {
-    color: "lime",
-    dot: "bg-lime-500",
-    label: "High confidence",
-  },
-  medium: {
-    color: "yellow",
-    dot: "bg-orange-500",
-    label: "Medium confidence",
-  },
-  low: {
-    color: "gray",
-    dot: "bg-foreground-icon-tertiary",
-    label: "Low confidence",
-  },
+const confidenceMeta: Record<Confidence, { bars: number; fill: string; label: string }> = {
+  high: { bars: 3, fill: "bg-lime-500", label: "High confidence" },
+  medium: { bars: 2, fill: "bg-orange-500", label: "Medium confidence" },
+  low: { bars: 1, fill: "bg-foreground-icon-tertiary", label: "Low confidence" },
 };
 
 export interface RecommendationCardProps {
@@ -65,13 +48,24 @@ export function RecommendationCard({
     >
       <div className="flex flex-col gap-1.5 p-4">
         <h3 className="text-body-medium text-text-primary">{title}</h3>
-        <div className="text-body-2-regular text-text-secondary">{body}</div>
+        <div className="min-h-12 text-body-2-regular leading-relaxed text-text-secondary">{body}</div>
       </div>
       <div className="flex items-center justify-between gap-3 border-t border-border-button-default bg-background-secondary-default px-4 py-3">
-        <Chip color={meta.color}>
-          <span className={cx("size-1.5 rounded-full", meta.dot)} aria-hidden />
-          {meta.label}
-        </Chip>
+        <div className="flex items-center gap-1.5">
+          <span className="flex items-end gap-0.5" aria-hidden>
+            {[0, 1, 2].map((i) => (
+              <span
+                key={i}
+                className={cx(
+                  "w-1 rounded-full",
+                  i === 0 ? "h-2" : i === 1 ? "h-2.5" : "h-3",
+                  i < meta.bars ? meta.fill : "bg-border-button-hover",
+                )}
+              />
+            ))}
+          </span>
+          <span className="text-caption-1-medium text-text-secondary">{meta.label}</span>
+        </div>
         <div className="flex items-center gap-2">
           {onAlternatives && (
             <Button

--- a/frontend/components/ai/search-list.tsx
+++ b/frontend/components/ai/search-list.tsx
@@ -19,8 +19,8 @@ export function SearchList() {
 
   return (
     <div className="w-full max-w-sm overflow-hidden rounded-2xl border border-border-button-default bg-background-primary-default shadow-md">
-      <label className="flex items-center gap-2 border-b border-border-button-default px-3 py-2.5">
-        <RiSearch2Line className="size-4 text-text-tertiary" />
+      <label className="flex h-10 items-center gap-2 border-b border-border-button-default px-3">
+        <RiSearch2Line className="size-3.5 text-text-tertiary" />
         <input
           value={query}
           onChange={(event) => setQuery(event.target.value)}
@@ -34,13 +34,13 @@ export function SearchList() {
           </button>
         ) : null}
       </label>
-      <div className="max-h-52 overflow-y-auto p-1.5">
+      <div className="max-h-52 overflow-y-auto p-1">
         {results.length ? (
           results.map((flavor) => (
             <button
               type="button"
               key={flavor}
-              className="flex w-full rounded-lg px-2.5 py-2 text-left text-body-2-regular text-text-secondary hover:bg-background-primary-hover hover:text-text-primary"
+              className="flex w-full h-8 rounded-md px-2 text-left text-body-2-regular text-text-primary hover:bg-background-primary-hover hover:text-text-primary"
             >
               {flavor}
             </button>

--- a/frontend/components/ai/selection-actions.tsx
+++ b/frontend/components/ai/selection-actions.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { RiCodeSSlashLine, RiFileCopyLine } from "@remixicon/react";
 import { AnimatePresence, MotionConfig, motion, useReducedMotion } from "motion/react";
 import {
   type KeyboardEvent,
@@ -232,20 +231,12 @@ export function SelectionActions({
     <MotionConfig reducedMotion="user" transition={{ duration: 0.22 }}>
       <div
         className={cx(
-          "relative flex min-h-[272px] w-full items-center overflow-hidden rounded-[24px] border border-[#303237] bg-[#18191b] px-5 py-16 shadow-card sm:px-14 lg:px-[72px]",
+          "relative flex min-h-[272px] w-full items-center overflow-hidden rounded-[24px] border border-border-button-default bg-background-primary-default px-5 py-12 shadow-card sm:px-14 lg:px-[72px]",
           className,
         )}
       >
-        <div className="absolute top-6 right-6 hidden items-center gap-2 sm:flex" aria-hidden>
-          <span className="inline-flex size-11 items-center justify-center rounded-[18px] border border-[#383a3f] bg-[#202124] text-text-secondary shadow-card">
-            <RiFileCopyLine className="size-5" />
-          </span>
-          <span className="inline-flex size-11 items-center justify-center rounded-[18px] border border-[#383a3f] bg-[#202124] text-text-secondary shadow-card">
-            <RiCodeSSlashLine className="size-5" />
-          </span>
-        </div>
-        <div ref={hostRef} className="relative mx-auto w-full max-w-[770px] pb-14">
-          <p className="text-[24px] leading-[1.45] text-text-primary">
+        <div ref={hostRef} className="relative mx-auto w-full max-w-[460px] pb-14">
+          <p className="text-body-2-regular leading-relaxed text-text-primary">
             {leadingText}
             <span
               ref={selectionRef}
@@ -253,12 +244,12 @@ export function SelectionActions({
                 "box-decoration-clone rounded-[3px] transition-[color,background-color] duration-200",
                 state.phase === "accepted"
                   ? "text-text-primary"
-                  : "bg-[#2a384c] text-text-primary",
+                  : "bg-accent-500/15 text-text-primary",
               )}
             >
               {displayText}
               {state.phase === "streaming" && (
-                <span className="ai-caret ml-0.5 inline-block h-4 w-px translate-y-0.5 bg-current align-text-bottom" />
+                <span className="ai-caret ml-0.5 inline-block h-3 w-px translate-y-0.5 bg-current align-text-bottom" />
               )}
             </span>
           </p>

--- a/frontend/components/ai/sidebar-nav.tsx
+++ b/frontend/components/ai/sidebar-nav.tsx
@@ -33,7 +33,7 @@ export function SidebarNav() {
   return (
     <nav
       className="w-full max-w-64 rounded-2xl border border-border-button-default bg-background-primary-default p-2 shadow-md"
-      aria-label="Beautiful UI workspace"
+      aria-label="Workspace navigation"
     >
       <label className="mb-3 flex items-center gap-2 rounded-lg bg-background-secondary-default px-2.5 py-2">
         <RiSearch2Line className="size-4 text-text-tertiary" />
@@ -46,7 +46,7 @@ export function SidebarNav() {
       </label>
       {["Workspace", "Objects"].map((section) => (
         <div key={section} className="mb-3">
-          <p className="px-2 py-1 text-mono-label text-text-tertiary">{section}</p>
+          <p className="px-2 py-1 text-body-2-medium text-text-tertiary">{section}</p>
           {visible
             .filter((item) => item.section === section)
             .map(({ key, label, icon: Icon, ...item }) => (
@@ -54,11 +54,11 @@ export function SidebarNav() {
                 key={key}
                 type="button"
                 onClick={() => setActive(key)}
-                className={`flex w-full items-center gap-2 rounded-lg px-2 py-2 text-body-2-medium transition-colors ${active === key ? "bg-linear-to-b from-accent-500 to-accent-600 text-white shadow-nav-selected" : "text-text-secondary hover:bg-background-primary-hover"}`}
+                className={`flex w-full items-center gap-2 rounded-[8px] px-2 py-1.5 text-body-medium transition-colors ${active === key ? "bg-linear-to-b from-accent-500 to-accent-600 text-white shadow-nav-selected" : "text-text-secondary hover:bg-background-primary-hover"}`}
               >
-                <Icon className="size-4" />
+                <Icon className="size-5" />
                 <span className="flex-1 text-left">{label}</span>
-                {"count" in item ? <span className="text-caption-1-regular">{item.count}</span> : null}
+                {"count" in item ? <span className="text-caption-1-medium tabular-nums opacity-70">{item.count}</span> : null}
                 {"add" in item ? <RiAddLine className="size-4" /> : null}
               </button>
             ))}

--- a/frontend/components/ai/streaming-text.tsx
+++ b/frontend/components/ai/streaming-text.tsx
@@ -101,7 +101,7 @@ function ActionButton({
       aria-pressed={active}
       onClick={onClick}
       className={cx(
-        "flex size-7 items-center justify-center rounded-lg transition-colors duration-100",
+        "flex size-6 items-center justify-center rounded-md transition-colors duration-100",
         "hover:bg-background-secondary-hover hover:text-text-secondary",
         active ? "text-text-primary" : "text-text-tertiary",
       )}
@@ -174,10 +174,10 @@ export function StreamingText({
 
   return (
     <div className={cx("w-full", className)}>
-      <p className="text-body-regular leading-relaxed whitespace-pre-wrap text-text-primary">
+      <p className="text-body-2-regular leading-relaxed whitespace-pre-wrap text-text-primary">
         {visible}
         {active && (
-          <span className="ai-caret ml-0.5 inline-block h-4 w-0.5 translate-y-0.5 rounded-full bg-foreground-icon-primary align-text-bottom" />
+          <span className="ai-caret ml-0.5 inline-block h-3 w-0.5 translate-y-0.5 rounded-full bg-foreground-icon-primary align-text-bottom" />
         )}
       </p>
 
@@ -220,7 +220,7 @@ export function StreamingText({
             type="button"
             aria-expanded={sourcesOpen}
             onClick={() => setSourcesOpen((o) => !o)}
-            className="ml-1.5 flex items-center gap-1.5 rounded-lg px-1.5 py-1 text-left transition-colors duration-150 hover:bg-background-secondary-hover"
+            className="ml-1.5 flex items-center gap-1.5 rounded-md px-1 py-0.5 text-left transition-colors duration-150 hover:bg-background-secondary-hover"
           >
             <span className="flex -space-x-1.5">
               {sources.slice(0, 3).map((source) => (
@@ -247,7 +247,7 @@ export function StreamingText({
           }}
         >
           <div className="overflow-hidden">
-            <div className="mt-1.5 flex flex-col rounded-xl border border-border-button-default bg-background-primary-default p-1 shadow-card">
+            <div className="mt-1.5 flex flex-col rounded-[10px] bg-background-primary-default p-1 shadow-sm">
               {sources.map((source) => (
                 <a
                   key={source.url}
@@ -258,7 +258,7 @@ export function StreamingText({
                 >
                   <SourceAvatar source={source} className="size-4 shrink-0 rounded" />
                   <span className="truncate">{source.name}</span>
-                  <span className="ml-auto shrink-0 font-mono text-caption-1-regular text-text-tertiary">
+                  <span className="ml-auto shrink-0 font-mono text-caption-2-regular text-text-tertiary">
                     {hostOf(source.url)}
                   </span>
                 </a>

--- a/frontend/components/ai/task-rows.tsx
+++ b/frontend/components/ai/task-rows.tsx
@@ -51,8 +51,8 @@ function StatusGlyph({
 }) {
   if (status === "done") {
     return (
-      <span className="animate-ai-fade-up bg-lime-500 text-text-white flex size-5 items-center justify-center rounded-full">
-        <RiCheckLine className="size-3" aria-hidden />
+      <span className="animate-ai-fade-up bg-lime-500 text-text-white flex size-5.5 items-center justify-center rounded-full">
+        <RiCheckLine className="size-[13px]" aria-hidden />
       </span>
     );
   }
@@ -104,7 +104,7 @@ function TaskCard({ task, delay }: { task: TaskRowItem; delay: number }) {
 
   return (
     <div
-      className="animate-ai-fade-up border-border-button-default bg-background-primary-default shadow-sm overflow-hidden rounded-2xl border"
+      className="animate-ai-fade-up bg-background-primary-default shadow-sm overflow-hidden rounded-[22px]"
       style={{ animationDelay: `${delay}ms` }}
     >
       <button
@@ -131,7 +131,7 @@ function TaskCard({ task, delay }: { task: TaskRowItem; delay: number }) {
         {task.statusLabel && (
           <span
             className={cx(
-              "inline-flex h-5 shrink-0 items-center rounded-full px-2 text-caption-1-medium",
+              "inline-flex h-5.5 shrink-0 items-center rounded-full px-2 text-caption-1-medium",
               pill[task.status],
             )}
           >

--- a/frontend/components/ai/thinking.tsx
+++ b/frontend/components/ai/thinking.tsx
@@ -45,15 +45,15 @@ export function Thinking({
         onClick={() => hasSteps && setExpanded((e) => !e)}
         disabled={!hasSteps}
         className={cx(
-          "-mx-1.5 flex w-fit items-center gap-1.5 rounded-md px-1.5 py-0.5 transition-colors duration-100",
+          "-mx-1.5 flex w-fit items-center gap-2 rounded-md px-1.5 py-1 transition-colors duration-100",
           hasSteps ? "hover:bg-background-secondary-hover" : "cursor-default",
         )}
       >
         <RiSparkling2Line className="size-3.5 shrink-0 text-text-secondary" aria-hidden />
         {active ? (
-          <span className="agent-progress-loading-text text-caption-1-medium">{label}</span>
+          <span className="agent-progress-loading-text text-body-2-medium">{label}</span>
         ) : (
-          <span className="text-caption-1-medium text-text-secondary">{label}</span>
+          <span className="text-body-2-medium text-text-secondary">{label}</span>
         )}
         {hasSteps && (
           <RiArrowDownSLine

--- a/frontend/styles/theme.css
+++ b/frontend/styles/theme.css
@@ -174,8 +174,11 @@
   --color-icon-button-disabled-foreground: var(--color-neutral-300);
   --color-button-primary-disabled-foreground: var(--color-neutral-400);
 
-  /* Text */
-  --color-text-primary:         var(--color-neutral-950);
+  /* Text - primary is a soft near-black (#242528) rather than pure neutral-950,
+   * so hover/active/dropdown text reads refined instead of harsh on light
+   * surfaces. neutral-950 stays available via text-strong-950 for true-black
+   * emphasis. */
+  --color-text-primary:         #242528;
   --color-text-secondary:       var(--color-neutral-500);
   --color-text-tertiary:        var(--color-neutral-400);
   --color-text-disabled:        var(--color-neutral-300);


### PR DESCRIPTION
Tightens the AI-kit lab components to a more faithful, consistent scale and softens light-theme primary text.

**Typography/color**
- Light-theme `--color-text-primary` -> soft near-black `#242528` (was pure `neutral-950`); `text-strong-950` stays available for true-black emphasis. Refines nav hover, active pills, dropdown text.

**AI-kit components (surgical, on our tokens)**
- Chat: two-line tool-result steps (label + tool name + duration -> result sentence).
- Streaming Text: 13px prose, compact caret/action buttons, lighter source panel.
- Recommendation: 3-bar confidence meter (replaces dot-chip) + body rhythm.
- Selection Actions: 13px reading text, raw-hex colors -> accent-tint/surface tokens, narrower column.
- Sidebar Nav: neutral aria-label + 14px labels/size-5 icons.
- Filter/Code/Search tables, Thinking, Task Rows, Approval, Context, Fine-tune: size/spacing/radius alignment.

Already-faithful components (Prompt Bar, Records Table, Insight, Tool Chips) left untouched. 14 files, +100/-93. Verified rendering in a running build; typecheck clean.