### PR TITLE
fix(dusk): active rail pill was near-white - add missing dark-blue selected token

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2300,6 +2300,10 @@ html {
   --color-team-menu-count-background:     hsl(var(--neutral-400));
   --color-team-menu-count-foreground:     hsl(var(--neutral-100));
   --color-notification-center-background: hsl(var(--neutral-900));
+  /* Selected pill (rail tab/toggle) is a dark-blue tint like the other dark
+   * themes; without this dusk inherited the light :root accent-50 and the active
+   * tab read as near-white. */
+  --color-pill-tab-blue-selected-background: color-mix(in srgb, hsl(var(--blue-900)) 60%, transparent);
   --color-pill-tab-blue-hover-background: hsl(var(--neutral-700));
 
   /* Borders and separators (error border keeps theme.css red) */


### PR DESCRIPTION
Dusk defined the pill-tab hover but not the selected background, so the active right-rail tab/toggle inherited the light :root accent-50 and read as near-white. Adds the dark-blue mix the other dark themes (dark/aura/harbor/phosphor/slate/sakura-night) already use. One line + comment.