### PR TITLE
Keep Usage navigation inside Settings

### DIFF
--- a/frontend/components/shell/thread-sidebar.tsx
+++ b/frontend/components/shell/thread-sidebar.tsx
@@ -1,6 +1,5 @@
 import {
   RiAddLine,
-  RiBarChartBoxLine,
   RiBookShelfLine,
   RiDashboardLine,
   RiSettings3Line,
@@ -14,17 +13,11 @@ import { ThemeToggle } from "./theme-toggle";
 import { UserMenu } from "./user-menu";
 import { WorkingProjectStatus } from "./working-project-status";
 
-export type ThreadSidebarActive = "new" | "dashboard" | "usage" | "library" | "settings";
+export type ThreadSidebarActive = "new" | "dashboard" | "library" | "settings";
 
 function ThreadSidebarFooter({ active }: { active?: ThreadSidebarActive }) {
   return (
     <nav aria-label="Workspace utilities" className="p-2">
-      <SidebarNavItem
-        href="/settings#usage"
-        icon={RiBarChartBoxLine}
-        label="Usage"
-        active={active === "usage"}
-      />
       <SidebarNavItem
         href="/settings"
         icon={RiSettings3Line}

--- a/frontend/components/shell/unified-shell-contract.test.ts
+++ b/frontend/components/shell/unified-shell-contract.test.ts
@@ -45,10 +45,10 @@ describe("unified shell contract", () => {
     );
   });
 
-  test("limits primary sidebar navigation to projects, threads, usage, customize, and settings", () => {
+  test("limits primary sidebar navigation to projects, threads, customize, and settings", () => {
     const { threadSidebar } = shellSources();
     const projectTree = read("../session-ui/project-thread-tree.tsx");
-    const primaryDestinations = ["Dashboard", "Threads", "Usage", "Customize", "Settings"];
+    const primaryDestinations = ["Dashboard", "Threads", "Customize", "Settings"];
     const displacedDestinations = [
       "New chat",
       "New task",
@@ -73,6 +73,8 @@ describe("unified shell contract", () => {
       expect(threadSidebar).not.toContain(`label='${label}'`);
     }
     expect(threadSidebar).not.toContain('label="All projects"');
+    expect(threadSidebar).not.toContain('label="Usage"');
+    expect(threadSidebar).not.toContain('href="/settings#usage"');
     expect(threadSidebar.match(/href="\/dashboard"/g)).toHaveLength(1);
   });
 


### PR DESCRIPTION
Summary
- Removes the duplicate Usage destination from the main workspace sidebar.
- Keeps the real Usage section and Settings rail entry unchanged.
- Adds explicit shell-contract assertions preventing the duplicate link from returning.

Verification
- Unified shell contract: 21/21 on the rewritten current main history.

No deployment included.