### PR TITLE
Sync deployed Daytona connection and release foundation

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,6 +1,23 @@
 # syntax=docker/dockerfile:1.7
 ARG BUN_IMAGE=oven/bun:1.3.14-slim@sha256:d56a2534ffd262e92c12fd3249d3924d296d97086da773f821d7d0477435ea04
 
+FROM ${BUN_IMAGE} AS codex-cli
+ARG NODE_VERSION=24.19.0
+ARG NODE_SHA256=14b342e71204f811bde6153be8e04b62aef63c236fef92b55f9c83154b409647
+ARG CODEX_CLI_VERSION=0.147.0
+USER root
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl xz-utils \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSLo /tmp/node.tar.xz \
+      "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" \
+    && printf '%s  %s\n' "$NODE_SHA256" /tmp/node.tar.xz | sha256sum -c - \
+    && tar -xJf /tmp/node.tar.xz --strip-components=1 -C /usr/local \
+    && rm /tmp/node.tar.xz \
+    && npm install --global "@openai/codex@${CODEX_CLI_VERSION}" \
+    && npm cache clean --force \
+    && codex --version | grep -Fx "codex-cli ${CODEX_CLI_VERSION}"
+
 FROM ${BUN_IMAGE} AS dependencies
 WORKDIR /app
 
@@ -29,6 +46,8 @@ ENV NODE_ENV=production \
 
 WORKDIR /app
 COPY --from=dependencies /app/backend/node_modules ./backend/node_modules
+COPY --from=codex-cli /usr/local/bin/node /usr/local/bin/node
+COPY --from=codex-cli /usr/local/lib/node_modules/@openai/codex /usr/local/lib/node_modules/@openai/codex
 COPY backend ./backend
 COPY packages/agent-client ./packages/agent-client
 COPY packages/agent-harness ./packages/agent-harness
@@ -37,6 +56,7 @@ COPY packages/artifact-workspace ./packages/artifact-workspace
 COPY packages/sandbox-contract ./packages/sandbox-contract
 
 RUN ln -s backend/node_modules /app/node_modules \
+    && ln -s ../lib/node_modules/@openai/codex/bin/codex.js /usr/local/bin/codex \
     && for package in agent-client agent-harness artifact-formats artifact-workspace sandbox-contract; do \
       rm -rf "/app/backend/node_modules/@useagent/${package}"; \
       ln -s "../../../packages/${package}" "/app/backend/node_modules/@useagent/${package}"; \
@@ -45,16 +65,20 @@ RUN ln -s backend/node_modules /app/node_modules \
       /app/backend/.artifacts \
       /app/backend/.runs \
       /app/backend/.slack-uploads \
+      /var/lib/useagent/codex-app-server \
       /opt/useagent/pi-runtime \
     && chown -R bun:bun \
       /app/backend/.artifacts \
       /app/backend/.runs \
       /app/backend/.slack-uploads \
+      /var/lib/useagent/codex-app-server \
       /opt/useagent/pi-runtime
+
+RUN codex --version | grep -Fx "codex-cli 0.147.0"
 
 USER bun
 WORKDIR /app/backend
 EXPOSE 3201
 HEALTHCHECK --interval=5s --timeout=3s --start-period=15s --retries=12 \
-  CMD ["bun", "-e", "fetch('http://127.0.0.1:3201/api/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
+  CMD ["bun", "-e", "fetch('http://127.0.0.1:'+(process.env.PORT||'3201')+'/api/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
 CMD ["bun", "run", "src/index.ts"]

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -54,5 +54,5 @@ USER node
 WORKDIR /app/frontend
 EXPOSE 3400
 HEALTHCHECK --interval=5s --timeout=3s --start-period=15s --retries=12 \
-  CMD ["node", "-e", "fetch('http://127.0.0.1:3400/healthz').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
+  CMD ["node", "-e", "fetch('http://127.0.0.1:'+(process.env.PORT||'3400')+'/healthz').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
 CMD ["node", "server.js"]

--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -46,5 +46,5 @@ USER bun
 WORKDIR /app/backend
 EXPOSE 3202
 HEALTHCHECK --interval=5s --timeout=3s --start-period=10s --retries=12 \
-  CMD ["bun", "-e", "fetch('http://127.0.0.1:3202/api/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
+  CMD ["bun", "-e", "fetch('http://127.0.0.1:'+(process.env.GATEWAY_PORT||'3202')+'/api/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
 CMD ["bun", "run", "src/gateway.ts"]

--- a/backend/drizzle/0073_daytona_user_connections.sql
+++ b/backend/drizzle/0073_daytona_user_connections.sql
@@ -1,0 +1,42 @@
+-- fast-deploy: expansion-safe
+-- Add a tenant-scoped Daytona connection without changing run routing.
+-- New checks are enforced for new/changed rows immediately. They remain
+-- NOT VALID so this release does no table scan while holding Drizzle's
+-- migration transaction; a later online validation can run independently.
+ALTER TABLE "provider_connections"
+  ADD CONSTRAINT "provider_connections_provider_check_v2"
+  CHECK ("provider" IN ('openai', 'anthropic', 'openrouter', 'daytona')) NOT VALID;
+--> statement-breakpoint
+ALTER TABLE "provider_connections"
+  DROP CONSTRAINT "provider_connections_provider_check";
+--> statement-breakpoint
+ALTER TABLE "provider_connections"
+  RENAME CONSTRAINT "provider_connections_provider_check_v2"
+  TO "provider_connections_provider_check";
+--> statement-breakpoint
+ALTER TABLE "provider_connections"
+  ADD CONSTRAINT "provider_connections_daytona_auth_check" CHECK (
+    "provider" <> 'daytona' OR "auth_method" = 'api_key'
+  ) NOT VALID;
+--> statement-breakpoint
+ALTER TABLE "provider_connections"
+  ADD CONSTRAINT "provider_connections_metadata_safe_check_v2" CHECK (
+    jsonb_typeof("metadata") = 'object'
+    AND ("metadata" - 'email' - 'planType' - 'snapshotName') = '{}'::jsonb
+    AND ("provider" = 'daytona' OR NOT ("metadata" ? 'snapshotName'))
+    AND ("provider" <> 'daytona' OR NOT ("metadata" ? 'email') AND NOT ("metadata" ? 'planType'))
+    AND (NOT ("metadata" ? 'email') OR jsonb_typeof("metadata"->'email') = 'string')
+    AND (NOT ("metadata" ? 'planType') OR jsonb_typeof("metadata"->'planType') = 'string')
+    AND (NOT ("metadata" ? 'snapshotName') OR (
+      jsonb_typeof("metadata"->'snapshotName') = 'string'
+      AND length("metadata"->>'snapshotName') BETWEEN 1 AND 200
+      AND ("metadata"->>'snapshotName') ~ '^[A-Za-z0-9][A-Za-z0-9._-]*$'
+    ))
+  ) NOT VALID;
+--> statement-breakpoint
+ALTER TABLE "provider_connections"
+  DROP CONSTRAINT "provider_connections_metadata_safe_check";
+--> statement-breakpoint
+ALTER TABLE "provider_connections"
+  RENAME CONSTRAINT "provider_connections_metadata_safe_check_v2"
+  TO "provider_connections_metadata_safe_check";

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -491,6 +491,13 @@
       "when": 1790900000000,
       "tag": "0071_slack_stream_progress",
       "breakpoints": true
+    },
+    {
+      "idx": 70,
+      "version": "7",
+      "when": 1791100000000,
+      "tag": "0073_daytona_user_connections",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/schema/provider-connections.ts
+++ b/backend/src/db/schema/provider-connections.ts
@@ -32,8 +32,8 @@ export {
 };
 
 // ---------------------------------------------------------------------------
-// Provider connections — per-user, per-organization credentials for model
-// providers. These are NOT sandbox secrets: plaintext is write-only at the HTTP
+// Provider connections — per-user, per-organization credentials for model and
+// explicitly supported infrastructure providers. These are NOT sandbox secrets: plaintext is write-only at the HTTP
 // boundary and decrypted only by trusted backend callers. Metadata is limited to
 // safe display fields; credential material is AES-256-GCM sealed with the shared
 // secrets crypto implementation.

--- a/backend/src/provider-connections/daytona.test.ts
+++ b/backend/src/provider-connections/daytona.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DaytonaConnectionValidationError,
+  daytonaValidationHttpStatus,
+  validateDaytonaConnection,
+} from "./daytona";
+
+describe("Daytona provider connection validation", () => {
+  test("accepts only the exact active snapshot without provisioning", async () => {
+    const calls: string[] = [];
+    await validateDaytonaConnection(
+      { apiKey: "secret", snapshotName: "useagent-runtime-v17" },
+      {
+        createClient: () => ({
+          snapshot: {
+            get: async (name) => {
+              calls.push(name);
+              return { name, state: "active" };
+            },
+          },
+        }),
+      },
+    );
+    expect(calls).toEqual(["useagent-runtime-v17"]);
+  });
+
+  test("rejects a non-active or mismatched snapshot", async () => {
+    for (const snapshot of [
+      { name: "useagent-runtime-v17", state: "building" },
+      { name: "other", state: "active" },
+    ]) {
+      await expect(validateDaytonaConnection(
+        { apiKey: "secret", snapshotName: "useagent-runtime-v17" },
+        { createClient: () => ({ snapshot: { get: async () => snapshot } }) },
+      )).rejects.toMatchObject({ code: "snapshot_not_active" });
+    }
+  });
+
+  test("preserves the validation result when SDK disposal fails", async () => {
+    await expect(validateDaytonaConnection(
+      { apiKey: "secret", snapshotName: "missing" },
+      {
+        createClient: () => ({
+          snapshot: {
+            get: async () => ({ name: "other", state: "active" }),
+          },
+          [Symbol.asyncDispose]: async () => {
+            throw new Error("dispose failed");
+          },
+        }),
+      },
+    )).rejects.toMatchObject({ code: "snapshot_not_active" });
+  });
+
+  test("fails a successful validation when SDK disposal fails", async () => {
+    await expect(validateDaytonaConnection(
+      { apiKey: "secret", snapshotName: "useagent-runtime-v17" },
+      {
+        createClient: () => ({
+          snapshot: {
+            get: async (name) => ({ name, state: "active" }),
+          },
+          [Symbol.asyncDispose]: async () => {
+            throw new Error("dispose failed");
+          },
+        }),
+      },
+    )).rejects.toMatchObject({ code: "provider_unavailable" });
+  });
+
+  test("maps validation codes to stable HTTP statuses", () => {
+    expect(daytonaValidationHttpStatus("authentication_failed")).toBe(401);
+    expect(daytonaValidationHttpStatus("forbidden")).toBe(403);
+    expect(daytonaValidationHttpStatus("snapshot_not_found")).toBe(404);
+    expect(daytonaValidationHttpStatus("snapshot_not_active")).toBe(409);
+    expect(daytonaValidationHttpStatus("rate_limited")).toBe(429);
+    expect(daytonaValidationHttpStatus("provider_unavailable")).toBe(503);
+    expect(new DaytonaConnectionValidationError("provider_unavailable").message).toBe(
+      "provider_unavailable",
+    );
+  });
+});

--- a/backend/src/provider-connections/daytona.ts
+++ b/backend/src/provider-connections/daytona.ts
@@ -1,0 +1,104 @@
+import {
+  Daytona,
+  DaytonaAuthenticationError,
+  DaytonaForbiddenError,
+  DaytonaNotFoundError,
+  DaytonaRateLimitError,
+  DaytonaServiceUnavailableError,
+  DaytonaTimeoutError,
+} from "@daytona/sdk";
+
+export type DaytonaConnectionValidationCode =
+  | "authentication_failed"
+  | "forbidden"
+  | "snapshot_not_found"
+  | "snapshot_not_active"
+  | "rate_limited"
+  | "provider_unavailable";
+
+export class DaytonaConnectionValidationError extends Error {
+  constructor(readonly code: DaytonaConnectionValidationCode) {
+    super(code);
+    this.name = "DaytonaConnectionValidationError";
+  }
+}
+
+export interface DaytonaConnectionValidatorClient {
+  readonly snapshot: {
+    get(name: string): Promise<{ readonly name: string; readonly state: string }>;
+  };
+  readonly [Symbol.asyncDispose]?: () => Promise<void>;
+}
+
+function normalizeDaytonaValidationError(error: unknown): unknown {
+  if (error instanceof DaytonaConnectionValidationError) return error;
+  if (error instanceof DaytonaAuthenticationError) {
+    return new DaytonaConnectionValidationError("authentication_failed");
+  }
+  if (error instanceof DaytonaForbiddenError) {
+    return new DaytonaConnectionValidationError("forbidden");
+  }
+  if (error instanceof DaytonaNotFoundError) {
+    return new DaytonaConnectionValidationError("snapshot_not_found");
+  }
+  if (error instanceof DaytonaRateLimitError) {
+    return new DaytonaConnectionValidationError("rate_limited");
+  }
+  if (error instanceof DaytonaTimeoutError || error instanceof DaytonaServiceUnavailableError) {
+    return new DaytonaConnectionValidationError("provider_unavailable");
+  }
+  return error;
+}
+
+export async function validateDaytonaConnection(
+  input: { readonly apiKey: string; readonly snapshotName: string },
+  deps: {
+    readonly createClient?: (apiKey: string) => DaytonaConnectionValidatorClient;
+  } = {},
+): Promise<void> {
+  const createClient = deps.createClient ?? ((apiKey: string) => new Daytona({
+    apiKey,
+    apiUrl: process.env.DAYTONA_API_URL?.trim() || "https://app.daytona.io/api",
+    target: process.env.DAYTONA_TARGET?.trim() || "us",
+    requestTimeoutMs: 15_000,
+    // Snapshot validation never observes sandbox state. Avoid opening the SDK's
+    // WebSocket event dispatcher for this one bounded metadata lookup.
+    useDeprecatedPolling: true,
+  }));
+  const client = createClient(input.apiKey);
+  let validationError: unknown = null;
+  try {
+    const snapshot = await client.snapshot.get(input.snapshotName);
+    if (snapshot.name !== input.snapshotName || snapshot.state !== "active") {
+      throw new DaytonaConnectionValidationError("snapshot_not_active");
+    }
+  } catch (error) {
+    validationError = normalizeDaytonaValidationError(error);
+  }
+  try {
+    await client[Symbol.asyncDispose]?.();
+  } catch {
+    console.warn("[provider-connections] Daytona validation client cleanup failed");
+    validationError ??= new DaytonaConnectionValidationError("provider_unavailable");
+  }
+  if (validationError) throw validationError;
+}
+
+export function daytonaValidationHttpStatus(
+  code: DaytonaConnectionValidationCode,
+): 401 | 403 | 404 | 409 | 429 | 503 {
+  switch (code) {
+    case "authentication_failed":
+      return 401;
+    case "forbidden":
+      return 403;
+    case "snapshot_not_found":
+      return 404;
+    case "snapshot_not_active":
+      return 409;
+    case "rate_limited":
+      return 429;
+    case "provider_unavailable":
+      return 503;
+  }
+}

--- a/backend/src/provider-connections/routes.ts
+++ b/backend/src/provider-connections/routes.ts
@@ -17,9 +17,15 @@ import {
   type ProviderConnectionMeta,
 } from "./service";
 import {
+  DaytonaConnectionValidationError,
+  daytonaValidationHttpStatus,
+  validateDaytonaConnection,
+} from "./daytona";
+import {
   isProviderConnectionAuthMethod,
   isProviderConnectionProvider,
-  readSafeMetadata,
+  readDaytonaConnectionMetadata,
+  readModelProviderMetadata,
   type ProviderConnectionAuthMethod,
 } from "./types";
 
@@ -49,9 +55,11 @@ const defaultCodexChatGptOAuthLifecycle: CodexChatGptOAuthLifecycle = {
 
 export function createProviderConnectionsRoutes(input: {
   codexChatGptOAuth?: CodexChatGptOAuthLifecycle;
+  validateDaytona?: typeof validateDaytonaConnection;
 } = {}): Hono<AppEnv> {
   const providerConnectionsRoutes = new Hono<AppEnv>();
   const codexChatGptOAuth = input.codexChatGptOAuth ?? defaultCodexChatGptOAuthLifecycle;
+  const validateDaytona = input.validateDaytona ?? validateDaytonaConnection;
 
   providerConnectionsRoutes.use("*", orgScope);
 
@@ -144,16 +152,36 @@ export function createProviderConnectionsRoutes(input: {
       return c.json({ error: "invalid JSON body" }, 400);
     }
 
-    const apiKey = typeof body.apiKey === "string" ? body.apiKey : "";
+    const apiKey = typeof body.apiKey === "string" ? body.apiKey.trim() : "";
     if (!apiKey) return c.json({ error: "apiKey is required" }, 400);
+    if (apiKey.length > 8_192) return c.json({ error: "apiKey is too long" }, 400);
 
     const scope = requireUserScope(c);
     if (!scope) return c.json({ error: "user_required" }, 403);
+
+    const daytonaMetadata = provider === "daytona"
+      ? readDaytonaConnectionMetadata(body.metadata)
+      : null;
+    if (provider === "daytona" && !daytonaMetadata) {
+      return c.json({ error: "valid Daytona snapshotName is required" }, 400);
+    }
+    const metadata = daytonaMetadata ?? readModelProviderMetadata(body.metadata);
+    if (provider === "daytona") {
+      try {
+        await validateDaytona({ apiKey, snapshotName: daytonaMetadata!.snapshotName });
+      } catch (error) {
+        if (error instanceof DaytonaConnectionValidationError) {
+          return c.json({ error: error.code }, daytonaValidationHttpStatus(error.code));
+        }
+        throw error;
+      }
+    }
+
     const connection = await upsertApiKeyProviderConnection({
       ...scope,
       provider,
       apiKey,
-      metadata: readSafeMetadata(body.metadata),
+      metadata,
     });
     return c.json({ connection });
   });

--- a/backend/src/provider-connections/types.ts
+++ b/backend/src/provider-connections/types.ts
@@ -5,6 +5,7 @@ import type {
   ProviderConnectionMetadata,
   ProviderConnectionProvider,
 } from "@useagent/agent-client/provider-connections";
+import { decodeProviderConnectionMetadata } from "@useagent/agent-client/provider-connections";
 
 export {
   decodeProviderConnectionMetadata as readSafeMetadata,
@@ -18,6 +19,33 @@ export type {
   ProviderConnectionMetadata,
   ProviderConnectionProvider,
 };
+
+export interface DaytonaConnectionMetadata {
+  readonly snapshotName: string;
+}
+
+export function readModelProviderMetadata(value: unknown): ProviderConnectionMetadata {
+  const metadata = decodeProviderConnectionMetadata(value);
+  return {
+    ...(metadata.email ? { email: metadata.email } : {}),
+    ...(metadata.planType ? { planType: metadata.planType } : {}),
+  };
+}
+
+export function readDaytonaConnectionMetadata(value: unknown): DaytonaConnectionMetadata | null {
+  const metadata = decodeProviderConnectionMetadata(value);
+  const snapshotName = metadata.snapshotName?.trim() ?? "";
+  if (
+    snapshotName.length < 1 ||
+    snapshotName.length > 200 ||
+    !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(snapshotName)
+  ) {
+    return null;
+  }
+  return {
+    snapshotName,
+  };
+}
 
 export interface ProviderConnectionCredential {
   authMethod: ProviderConnectionAuthMethod;

--- a/backend/test/provider-connections.test.ts
+++ b/backend/test/provider-connections.test.ts
@@ -23,6 +23,7 @@ import {
   type ManagedCodexAppServerClient,
 } from "../src/provider-connections/codex-app-server";
 import { createProviderConnectionsRoutes, type CodexChatGptOAuthLifecycle } from "../src/provider-connections/routes";
+import { DaytonaConnectionValidationError } from "../src/provider-connections/daytona";
 import {
   getCurrentUserProviderConnection,
   getCodexSubscriptionRuntimeSelection,
@@ -85,6 +86,7 @@ describe("provider connections", () => {
         metadata: {
           email: "person@example.com",
           planType: "team",
+          snapshotName: "must-not-persist-for-model-provider",
           accessToken: "must-not-persist-as-metadata",
         },
       },
@@ -128,6 +130,129 @@ describe("provider connections", () => {
       authMethod: "api_key",
     });
     expect(trusted).toEqual({ authMethod: "api_key", value: apiKey });
+  });
+
+  test("Daytona key and snapshot are tenant-scoped and write-only", async () => {
+    const session = await createOrgSession("pc-daytona");
+    const userId = await userIdForEmail(session.email);
+    const apiKey = `dtn_${crypto.randomUUID()}`;
+    const validations: Array<{ apiKey: string; snapshotName: string }> = [];
+    const app = new Hono<AppEnv>().route(
+      "/api/provider-connections",
+      createProviderConnectionsRoutes({
+        validateDaytona: async (input) => {
+          validations.push(input);
+        },
+      }),
+    );
+
+    const connected = await customJson<{ connection: ProviderConnectionMeta }>(
+      app,
+      "/api/provider-connections/daytona/api-key",
+      {
+        method: "PUT",
+        cookies: session.cookies,
+        body: {
+          apiKey,
+          metadata: {
+            snapshotName: "useagent-runtime-v17",
+            email: "must-not-survive@example.com",
+          },
+        },
+      },
+    );
+    expect(connected.status).toBe(200);
+    expect(connected.body.connection).toMatchObject({
+      provider: "daytona",
+      authMethod: "api_key",
+      status: "connected",
+      metadata: {
+        snapshotName: "useagent-runtime-v17",
+      },
+    });
+    expect(connected.body.connection.metadata.email).toBeUndefined();
+    assertNoCredentialMaterial(connected.body, apiKey);
+
+    expect(validations).toEqual([
+      { apiKey, snapshotName: "useagent-runtime-v17" },
+    ]);
+    expect(await getTrustedProviderCredential({
+      orgId: session.orgId,
+      userId,
+      provider: "daytona",
+      authMethod: "api_key",
+    })).toEqual({ authMethod: "api_key", value: apiKey });
+
+    const invalid = await customJson(
+      app,
+      "/api/provider-connections/daytona/api-key",
+      {
+        method: "PUT",
+        cookies: session.cookies,
+        body: { apiKey: "next-key", metadata: { snapshotName: "bad snapshot" } },
+      },
+    );
+    expect(invalid).toEqual({
+      status: 400,
+      body: { error: "valid Daytona snapshotName is required" },
+    });
+  });
+
+  test("Daytona validation failure persists no connection or credential material", async () => {
+    const session = await createOrgSession("pc-daytona-invalid");
+    const userId = await userIdForEmail(session.email);
+    const apiKey = `dtn_invalid_${crypto.randomUUID()}`;
+    const app = new Hono<AppEnv>().route(
+      "/api/provider-connections",
+      createProviderConnectionsRoutes({
+        validateDaytona: async () => {
+          throw new DaytonaConnectionValidationError("snapshot_not_found");
+        },
+      }),
+    );
+    const response = await customJson(
+      app,
+      "/api/provider-connections/daytona/api-key",
+      {
+        method: "PUT",
+        cookies: session.cookies,
+        body: {
+          apiKey,
+          metadata: { snapshotName: "missing-snapshot" },
+        },
+      },
+    );
+    expect(response).toEqual({ status: 404, body: { error: "snapshot_not_found" } });
+    expect(await getTrustedProviderCredential({
+      orgId: session.orgId,
+      userId,
+      provider: "daytona",
+      authMethod: "api_key",
+    })).toBeNull();
+    assertNoCredentialMaterial(response, apiKey);
+  });
+
+  test("Daytona schema rejects OAuth rows and provider-incompatible metadata", async () => {
+    const base = {
+      orgId: `org_${crypto.randomUUID()}`,
+      userId: `user_${crypto.randomUUID()}`,
+      status: "connected" as const,
+      credentialCiphertext: "sealed",
+      iv: "iv",
+      tag: "tag",
+    };
+    await expect(db.insert(providerConnections).values({
+      ...base,
+      provider: "daytona",
+      authMethod: "chatgpt_oauth",
+      metadata: { snapshotName: "runtime-v1" },
+    }).execute()).rejects.toThrow();
+    await expect(db.insert(providerConnections).values({
+      ...base,
+      provider: "openai",
+      authMethod: "api_key",
+      metadata: { snapshotName: "runtime-v1" },
+    }).execute()).rejects.toThrow();
   });
 
   test("connections are isolated by user and organization for read, update, and revoke", async () => {

--- a/compose.local.yaml
+++ b/compose.local.yaml
@@ -1,0 +1,125 @@
+name: useagent-local
+
+services:
+  postgres:
+    image: pgvector/pgvector:pg16-bookworm@sha256:ccc6e83d6e35e931dc7c5def2022729d5a6c370318d099181995567ff1fb4d6b
+    environment:
+      POSTGRES_DB: useagent
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d useagent"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+    volumes:
+      - useagent-postgres:/var/lib/postgresql/data
+      - ./deploy/compose/postgres-init.sql:/docker-entrypoint-initdb.d/10-gateway-role.sql:ro
+
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
+      args:
+        RELEASE_COMMIT: ${RELEASE_COMMIT:?set RELEASE_COMMIT in .env.compose}
+    image: useagent-local/backend:${RELEASE_COMMIT}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      NODE_ENV: production
+      PORT: 3201
+      USEAGENT_BIND_HOST: 0.0.0.0
+      USEAGENT_DEV_MODE: "false"
+      REQUIRE_SINGLE_BACKEND: "true"
+      DATABASE_URL: postgres://postgres:postgres@postgres:5432/useagent
+      FRONTEND_ORIGIN: http://localhost:3400
+      BETTER_AUTH_URL: http://localhost:3400
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?set BETTER_AUTH_SECRET in .env.compose}
+      SECRETS_ENCRYPTION_KEY: ${SECRETS_ENCRYPTION_KEY:?set SECRETS_ENCRYPTION_KEY in .env.compose}
+      USEAGENT_OPERATOR_SECRET: ${USEAGENT_OPERATOR_SECRET:?set USEAGENT_OPERATOR_SECRET in .env.compose}
+      GATEWAY_PUBLIC_URL: ${GATEWAY_PUBLIC_URL:?set a sandbox-reachable HTTPS gateway origin}
+      PROVIDER_GATEWAY_PUBLIC_URL: ${GATEWAY_PUBLIC_URL}
+      PROVIDER_GATEWAY_SECRET: ${PROVIDER_GATEWAY_SECRET:?set PROVIDER_GATEWAY_SECRET in .env.compose}
+      TOOL_GATEWAY_SECRET: ${TOOL_GATEWAY_SECRET:?set TOOL_GATEWAY_SECRET in .env.compose}
+      CODEX_APP_SERVER_HOME_ROOT: /var/lib/useagent/codex-app-server
+      SANDBOX_PROVIDER: ${SANDBOX_PROVIDER:-daytona}
+      DAYTONA_API_KEY: ${DAYTONA_API_KEY:-}
+      DAYTONA_TARGET: ${DAYTONA_TARGET:-us}
+      DAYTONA_SNAPSHOT: ${DAYTONA_SNAPSHOT:-skynet-agent-v17}
+      CUBE_API_URL: ${CUBE_API_URL:-}
+      CUBE_API_KEY: ${CUBE_API_KEY:-}
+      CUBE_TEMPLATE_ID: ${CUBE_TEMPLATE_ID:-}
+      CUBE_SANDBOX_DOMAIN: ${CUBE_SANDBOX_DOMAIN:-cube.app}
+    ports:
+      - "127.0.0.1:3201:3201"
+    volumes:
+      - useagent-artifacts:/app/backend/.artifacts
+      - useagent-runs:/app/backend/.runs
+      - useagent-slack-uploads:/app/backend/.slack-uploads
+      - useagent-pi-runtime:/opt/useagent/pi-runtime
+      - useagent-codex-app-server:/var/lib/useagent/codex-app-server
+    restart: unless-stopped
+
+  gateway:
+    build:
+      context: .
+      dockerfile: Dockerfile.gateway
+      args:
+        RELEASE_COMMIT: ${RELEASE_COMMIT:?set RELEASE_COMMIT in .env.compose}
+    image: useagent-local/gateway:${RELEASE_COMMIT}
+    depends_on:
+      backend:
+        condition: service_healthy
+    environment:
+      NODE_ENV: production
+      GATEWAY_PORT: 3202
+      USEAGENT_BIND_HOST: 0.0.0.0
+      USEAGENT_DEV_MODE: "false"
+      GATEWAY_DATABASE_URL: postgres://useagent_gateway:gateway@postgres:5432/useagent
+      PROVIDER_GATEWAY_SECRET: ${PROVIDER_GATEWAY_SECRET:?set PROVIDER_GATEWAY_SECRET in .env.compose}
+      TOOL_GATEWAY_SECRET: ${TOOL_GATEWAY_SECRET:?set TOOL_GATEWAY_SECRET in .env.compose}
+      SECRETS_ENCRYPTION_KEY: ${SECRETS_ENCRYPTION_KEY:?set SECRETS_ENCRYPTION_KEY in .env.compose}
+      FRONTEND_ORIGIN: http://localhost:3400
+      USEAGENT_API_ORIGIN: http://backend:3201
+      GATEWAY_PUBLIC_URL: ${GATEWAY_PUBLIC_URL:?set a sandbox-reachable HTTPS gateway origin}
+      PROVIDER_GATEWAY_PUBLIC_URL: ${GATEWAY_PUBLIC_URL}
+      SANDBOX_PROVIDER: ${SANDBOX_PROVIDER:-daytona}
+      DAYTONA_API_KEY: ${DAYTONA_API_KEY:-}
+      DAYTONA_API_URL: ${DAYTONA_API_URL:-https://app.daytona.io/api}
+      DAYTONA_TARGET: ${DAYTONA_TARGET:-us}
+      CUBE_API_URL: ${CUBE_API_URL:-}
+      CUBE_API_KEY: ${CUBE_API_KEY:-}
+      CUBE_TEMPLATE_ID: ${CUBE_TEMPLATE_ID:-}
+      CUBE_SANDBOX_DOMAIN: ${CUBE_SANDBOX_DOMAIN:-cube.app}
+    ports:
+      - "127.0.0.1:3202:3202"
+    restart: unless-stopped
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+      args:
+        RELEASE_COMMIT: ${RELEASE_COMMIT:?set RELEASE_COMMIT in .env.compose}
+    image: useagent-local/frontend:${RELEASE_COMMIT}
+    depends_on:
+      backend:
+        condition: service_healthy
+    environment:
+      NODE_ENV: production
+      HOSTNAME: 0.0.0.0
+      PORT: 3400
+      USEAGENT_API_ORIGIN: http://backend:3201
+      NEXT_PUBLIC_USEAGENT_RELEASE_COMMIT: ${RELEASE_COMMIT}
+    ports:
+      - "127.0.0.1:3400:3400"
+    restart: unless-stopped
+
+volumes:
+  useagent-artifacts:
+  useagent-codex-app-server:
+  useagent-pi-runtime:
+  useagent-postgres:
+  useagent-runs:
+  useagent-slack-uploads:

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,0 +1,61 @@
+name: useagent-${USEAGENT_RELEASE_COLOR:?set USEAGENT_RELEASE_COLOR to blue or green}
+
+services:
+  backend:
+    image: ${USEAGENT_BACKEND_IMAGE:?set an immutable backend image digest}
+    network_mode: host
+    env_file:
+      - ${USEAGENT_BACKEND_ENV_FILE:-/etc/useagent/backend.env}
+    environment:
+      NODE_ENV: production
+      PORT: ${USEAGENT_BACKEND_PORT:?set the inactive-color backend port}
+      USEAGENT_BIND_HOST: 127.0.0.1
+      USEAGENT_RELEASE_COMMIT: ${USEAGENT_RELEASE_COMMIT:?set the exact release commit}
+      REQUIRE_SINGLE_BACKEND: "true"
+      CODEX_APP_SERVER_HOME_ROOT: /var/lib/useagent/codex-app-server
+      GATEWAY_PUBLIC_URL: ${USEAGENT_GATEWAY_PUBLIC_URL:?set the sandbox-reachable HTTPS gateway origin}
+      PROVIDER_GATEWAY_PUBLIC_URL: ${USEAGENT_GATEWAY_PUBLIC_URL}
+    read_only: true
+    tmpfs:
+      - /tmp:size=256m,mode=1777
+    volumes:
+      - /var/lib/useagent/artifacts:/app/backend/.artifacts
+      - /var/lib/useagent/runs:/app/backend/.runs
+      - /var/lib/useagent/slack-uploads:/app/backend/.slack-uploads
+      - /var/lib/useagent/codex-app-server:/var/lib/useagent/codex-app-server
+      - /opt/useagent/pi-runtime:/opt/useagent/pi-runtime
+    restart: unless-stopped
+    stop_grace_period: 30s
+
+  gateway:
+    image: ${USEAGENT_GATEWAY_IMAGE:?set an immutable gateway image digest}
+    network_mode: host
+    env_file:
+      - ${USEAGENT_GATEWAY_ENV_FILE:-/etc/useagent/gateway.env}
+    environment:
+      NODE_ENV: production
+      GATEWAY_PORT: ${USEAGENT_GATEWAY_PORT:?set the inactive-color gateway port}
+      USEAGENT_BIND_HOST: 127.0.0.1
+      USEAGENT_RELEASE_COMMIT: ${USEAGENT_RELEASE_COMMIT:?set the exact release commit}
+      GATEWAY_PUBLIC_URL: ${USEAGENT_GATEWAY_PUBLIC_URL:?set the sandbox-reachable HTTPS gateway origin}
+      PROVIDER_GATEWAY_PUBLIC_URL: ${USEAGENT_GATEWAY_PUBLIC_URL}
+    read_only: true
+    tmpfs:
+      - /tmp:size=128m,mode=1777
+    restart: unless-stopped
+    stop_grace_period: 30s
+
+  frontend:
+    image: ${USEAGENT_FRONTEND_IMAGE:?set an immutable frontend image digest}
+    network_mode: host
+    environment:
+      NODE_ENV: production
+      HOSTNAME: 127.0.0.1
+      PORT: ${USEAGENT_FRONTEND_PORT:?set the inactive-color frontend port}
+      USEAGENT_API_ORIGIN: http://127.0.0.1:${USEAGENT_BACKEND_PORT}
+      NEXT_PUBLIC_USEAGENT_RELEASE_COMMIT: ${USEAGENT_RELEASE_COMMIT}
+    read_only: true
+    tmpfs:
+      - /tmp:size=128m,mode=1777
+    restart: unless-stopped
+    stop_grace_period: 30s

--- a/deploy/compose/env.example
+++ b/deploy/compose/env.example
@@ -1,0 +1,22 @@
+# Local Compose only. Copy to .env.compose and replace every development secret.
+RELEASE_COMMIT=0000000000000000000000000000000000000000
+BETTER_AUTH_SECRET=replace-with-at-least-32-random-characters
+SECRETS_ENCRYPTION_KEY=replace-with-64-hex-characters
+USEAGENT_OPERATOR_SECRET=replace-with-random-operator-secret
+PROVIDER_GATEWAY_SECRET=replace-with-random-provider-gateway-secret
+TOOL_GATEWAY_SECRET=replace-with-random-tool-gateway-secret
+GATEWAY_PUBLIC_URL=https://replace-with-your-sandbox-reachable-gateway.example
+
+# Select one sandbox provider for local runs. Cube remains external to Compose.
+SANDBOX_PROVIDER=daytona
+DAYTONA_API_KEY=
+DAYTONA_API_URL=https://app.daytona.io/api
+DAYTONA_TARGET=us
+DAYTONA_SNAPSHOT=skynet-agent-v17
+
+# To use an external Cube development VM instead:
+# SANDBOX_PROVIDER=cube
+# CUBE_API_URL=http://host.docker.internal:3000
+# CUBE_API_KEY=e2b_000000
+# CUBE_TEMPLATE_ID=<template-id>
+# CUBE_SANDBOX_DOMAIN=cube.app

--- a/deploy/compose/postgres-init.sql
+++ b/deploy/compose/postgres-init.sql
@@ -1,0 +1,1 @@
+CREATE ROLE useagent_gateway LOGIN PASSWORD 'gateway';

--- a/deploy/compose/release-config.test.ts
+++ b/deploy/compose/release-config.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { productionComposeReleaseConfig } from "./release-config";
+
+const valid = {
+  USEAGENT_RELEASE_COLOR: "green",
+  USEAGENT_RELEASE_COMMIT: "a".repeat(40),
+  USEAGENT_GATEWAY_PUBLIC_URL: "https://gateway.useagent.example",
+  USEAGENT_BACKEND_IMAGE: `ghcr.io/useagenthq/useagent-backend@sha256:${"b".repeat(64)}`,
+  USEAGENT_GATEWAY_IMAGE: `ghcr.io/useagenthq/useagent-gateway@sha256:${"c".repeat(64)}`,
+  USEAGENT_FRONTEND_IMAGE: `ghcr.io/useagenthq/useagent-frontend@sha256:${"d".repeat(64)}`,
+  USEAGENT_BACKEND_PORT: "3211",
+  USEAGENT_GATEWAY_PORT: "3212",
+  USEAGENT_FRONTEND_PORT: "3410",
+} as const;
+
+describe("production Compose release config", () => {
+  test("accepts exact digests and the fixed inactive-color ports", () => {
+    expect(productionComposeReleaseConfig(valid)).toEqual({
+      color: "green",
+      commit: "a".repeat(40),
+      publicGatewayUrl: "https://gateway.useagent.example",
+      images: {
+        backend: valid.USEAGENT_BACKEND_IMAGE,
+        gateway: valid.USEAGENT_GATEWAY_IMAGE,
+        frontend: valid.USEAGENT_FRONTEND_IMAGE,
+      },
+      ports: { backend: 3211, gateway: 3212, frontend: 3410 },
+    });
+  });
+
+  test("rejects tags, digest drift, and a color/port mismatch", () => {
+    expect(() => productionComposeReleaseConfig({
+      ...valid,
+      USEAGENT_BACKEND_IMAGE: "ghcr.io/useagenthq/useagent-backend:latest",
+    })).toThrow("immutable sha256 reference");
+    expect(() => productionComposeReleaseConfig({
+      ...valid,
+      USEAGENT_GATEWAY_IMAGE: `${valid.USEAGENT_GATEWAY_IMAGE}0`,
+    })).toThrow("immutable sha256 reference");
+    expect(() => productionComposeReleaseConfig({
+      ...valid,
+      USEAGENT_RELEASE_COLOR: "blue",
+    })).toThrow("USEAGENT_BACKEND_PORT must be 3201 for blue");
+    expect(() => productionComposeReleaseConfig({
+      ...valid,
+      USEAGENT_GATEWAY_PUBLIC_URL: "http://gateway:3202",
+    })).toThrow("absolute HTTPS origin");
+    expect(() => productionComposeReleaseConfig({
+      ...valid,
+      USEAGENT_GATEWAY_PUBLIC_URL: "https://gateway.useagent.example/path",
+    })).toThrow("absolute HTTPS origin");
+  });
+});

--- a/deploy/compose/release-config.ts
+++ b/deploy/compose/release-config.ts
@@ -1,0 +1,82 @@
+export interface ComposeReleaseConfig {
+  readonly color: "blue" | "green";
+  readonly commit: string;
+  readonly publicGatewayUrl: string;
+  readonly images: {
+    readonly backend: string;
+    readonly gateway: string;
+    readonly frontend: string;
+  };
+  readonly ports: {
+    readonly backend: number;
+    readonly gateway: number;
+    readonly frontend: number;
+  };
+}
+
+const IMAGE_DIGEST = /^[a-z0-9][a-z0-9._/-]*@sha256:[0-9a-f]{64}$/;
+const PORTS = {
+  blue: { backend: 3201, gateway: 3202, frontend: 3400 },
+  green: { backend: 3211, gateway: 3212, frontend: 3410 },
+} as const;
+
+export function productionComposeReleaseConfig(
+  env: Readonly<Record<string, string | undefined>>,
+): ComposeReleaseConfig {
+  const color = env.USEAGENT_RELEASE_COLOR;
+  if (color !== "blue" && color !== "green") {
+    throw new Error("USEAGENT_RELEASE_COLOR must be blue or green");
+  }
+  const commit = env.USEAGENT_RELEASE_COMMIT?.trim() ?? "";
+  if (!/^[0-9a-f]{40}$/.test(commit)) {
+    throw new Error("USEAGENT_RELEASE_COMMIT must be an exact Git commit");
+  }
+  const rawPublicGatewayUrl = env.USEAGENT_GATEWAY_PUBLIC_URL?.trim() ?? "";
+  let publicGatewayUrl: URL;
+  try {
+    publicGatewayUrl = new URL(rawPublicGatewayUrl);
+  } catch {
+    throw new Error("USEAGENT_GATEWAY_PUBLIC_URL must be an absolute HTTPS origin");
+  }
+  if (
+    publicGatewayUrl.protocol !== "https:" ||
+    publicGatewayUrl.username ||
+    publicGatewayUrl.password ||
+    publicGatewayUrl.pathname !== "/" ||
+    publicGatewayUrl.search ||
+    publicGatewayUrl.hash
+  ) {
+    throw new Error("USEAGENT_GATEWAY_PUBLIC_URL must be an absolute HTTPS origin");
+  }
+  const image = (name: "BACKEND" | "GATEWAY" | "FRONTEND"): string => {
+    const value = env[`USEAGENT_${name}_IMAGE`]?.trim() ?? "";
+    if (!IMAGE_DIGEST.test(value)) {
+      throw new Error(`USEAGENT_${name}_IMAGE must be an immutable sha256 reference`);
+    }
+    return value;
+  };
+  const expectedPorts = PORTS[color];
+  const port = (name: "BACKEND" | "GATEWAY" | "FRONTEND"): number => {
+    const value = Number(env[`USEAGENT_${name}_PORT`]);
+    const expected = expectedPorts[name.toLowerCase() as keyof typeof expectedPorts];
+    if (value !== expected) {
+      throw new Error(`USEAGENT_${name}_PORT must be ${expected} for ${color}`);
+    }
+    return value;
+  };
+  return {
+    color,
+    commit,
+    publicGatewayUrl: publicGatewayUrl.origin,
+    images: {
+      backend: image("BACKEND"),
+      gateway: image("GATEWAY"),
+      frontend: image("FRONTEND"),
+    },
+    ports: {
+      backend: port("BACKEND"),
+      gateway: port("GATEWAY"),
+      frontend: port("FRONTEND"),
+    },
+  };
+}

--- a/deploy/compose/validate-release.ts
+++ b/deploy/compose/validate-release.ts
@@ -1,0 +1,13 @@
+import { productionComposeReleaseConfig } from "./release-config";
+
+const config = productionComposeReleaseConfig(process.env);
+console.log(JSON.stringify({
+  ok: true,
+  color: config.color,
+  commit: config.commit,
+  publicGatewayUrl: config.publicGatewayUrl,
+  imageDigests: Object.fromEntries(
+    Object.entries(config.images).map(([name, image]) => [name, image.split("@", 2)[1]]),
+  ),
+  ports: config.ports,
+}));

--- a/docs/operations/compose-releases.md
+++ b/docs/operations/compose-releases.md
@@ -1,0 +1,73 @@
+# Compose application releases
+
+UseAgent uses the same immutable backend, gateway, and frontend images for local
+parity, the single Hetzner application host, and the later Kubernetes lane.
+CubeSandbox is infrastructure outside these Compose projects.
+
+## Local parity
+
+```bash
+cp deploy/compose/env.example .env.compose
+# Replace every placeholder and set RELEASE_COMMIT to `git rev-parse HEAD`.
+docker compose --env-file .env.compose -f compose.local.yaml up --build
+```
+
+The local project owns only disposable/development PostgreSQL and application
+volumes. Set `SANDBOX_PROVIDER=daytona` with a development Daytona key, or point
+the containers at a Cube Linux development VM. macOS Docker does not replace
+Cube's Linux VM/kernel requirements.
+
+`GATEWAY_PUBLIC_URL` must be an HTTPS origin reachable from the external
+sandbox. A Docker service name is neither a valid public gateway origin nor
+resolvable from Daytona/Cube. Use a development tunnel or a real development
+gateway domain; do not weaken the production URL validator.
+
+## Hetzner candidate project
+
+`compose.prod.yaml` accepts only caller-supplied image references. The private
+release orchestrator must run `bun deploy/compose/validate-release.ts` and pass
+the validated registry digests, not mutable tags, into Compose:
+
+```text
+ghcr.io/useagenthq/useagent-backend@sha256:...
+ghcr.io/useagenthq/useagent-gateway@sha256:...
+ghcr.io/useagenthq/useagent-frontend@sha256:...
+```
+
+It must also set `USEAGENT_GATEWAY_PUBLIC_URL` to the credential-free HTTPS
+origin reachable by tenant sandboxes. Candidate validation rejects HTTP,
+credentials, paths, query strings, and fragments before Compose starts.
+
+Blue and green projects use separate loopback ports. Frontend and gateway
+candidates may overlap where their database/runtime contracts permit, but the
+backend may not: provider sealing and realtime fan-out remain process-local and
+`REQUIRE_SINGLE_BACKEND=true` must stay enabled.
+
+The backend cutover is therefore serialized:
+
+1. Close run admission and drain the active backend.
+2. Stop the active backend.
+3. Start the candidate backend on the inactive-color port.
+4. Run migration, loopback health, release fingerprint, and bounded smoke gates.
+5. Validate Caddy and atomically switch its upstream.
+6. Keep the prior image and environment ready, with its backend stopped.
+
+Rollback stops the candidate backend, restarts the prior backend, verifies its
+loopback health, then reverses Caddy and reopens admission. Never disable the
+single-backend guard to simulate overlapping blue/green backends.
+
+Do not run an in-place `docker compose up` against the active color as a release
+procedure. Do not include Cube, host PostgreSQL, memory, OpenConnector, or Caddy
+in the application project during the first cutover.
+
+The production Compose definition is a dormant foundation until the private
+serialized-cutover orchestrator, container UID/mount preflight, and rollback
+rehearsal are complete. In particular, candidate preflight must prove the pinned
+`codex` executable is present and the mounted `CODEX_APP_SERVER_HOME_ROOT` is
+writable by the backend container user.
+
+The gateway environment must contain only gateway-owned configuration. Current
+computer/recording/repository tools still need the single deployment-selected
+sandbox provider credential; configure only that active provider's key and
+endpoint/template fields. Never place both Cube and Daytona control credentials
+in the gateway environment, and never copy the backend environment wholesale.

--- a/frontend/app/settings/daytona-connection-card.test.tsx
+++ b/frontend/app/settings/daytona-connection-card.test.tsx
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { DaytonaConnectionCard } from "./daytona-connection-card";
+import { ProviderConnectionsProvider } from "./use-provider-connections";
+
+test("renders an honest loading shell without credential material", () => {
+  const html = renderToStaticMarkup(
+    createElement(ProviderConnectionsProvider, null, createElement(DaytonaConnectionCard)),
+  );
+  expect(html).toContain("Managed Cube");
+  expect(html).toContain("Daytona");
+  expect(html).toContain("Loading Daytona connection...");
+  expect(html).not.toContain("DAYTONA_API_KEY");
+  expect(html).not.toContain("credentialCiphertext");
+});

--- a/frontend/app/settings/daytona-connection-card.tsx
+++ b/frontend/app/settings/daytona-connection-card.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import {
+  RiCloudLine,
+  RiKey2Line,
+  RiLoader4Line,
+  RiRefreshLine,
+  RiStackLine,
+} from "@remixicon/react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/base/buttons/button";
+import { InputBase } from "@/components/base/input/input";
+import { BackendUnreachable } from "@/components/shared/backend-unreachable";
+import { cx } from "@/utils/cx";
+import { ConnectionStatusChip, SpinnerIcon } from "./connection-status-chip";
+import { putProviderApiKey, revokeProviderConnection } from "./provider-connections-api";
+import {
+  connectionBadgeStatus,
+  isActiveConnection,
+  safeDaytonaMetadata,
+  statusLabel,
+} from "./provider-connections-data";
+import { relTime } from "./relative-time";
+import { useProviderConnections } from "./use-provider-connections";
+
+const MASK = "••••••••";
+
+export function DaytonaConnectionCard() {
+  const { connections, error, load, loading, refreshing } = useProviderConnections();
+  const connection = useMemo(
+    () =>
+      connections.find((item) => item.provider === "daytona" && item.authMethod === "api_key") ??
+      null,
+    [connections],
+  );
+  const connected = isActiveConnection(connection);
+  const [apiKey, setApiKey] = useState("");
+  const [snapshotName, setSnapshotName] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [revoking, setRevoking] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSnapshotName(connection?.metadata.snapshotName ?? "");
+  }, [connection?.metadata.snapshotName]);
+
+  const metadata = safeDaytonaMetadata({ snapshotName });
+  const save = useCallback(async () => {
+    const nextMetadata = safeDaytonaMetadata({ snapshotName });
+    if (!nextMetadata) return;
+    const key = apiKey.trim();
+    if (!key) return;
+    setSaving(true);
+    setFormError(null);
+    try {
+      await putProviderApiKey({ provider: "daytona", apiKey: key, metadata: nextMetadata });
+      setApiKey("");
+      await load();
+    } catch {
+      setFormError("Couldn't validate the Daytona key and snapshot. Check both values and retry.");
+    } finally {
+      setSaving(false);
+    }
+  }, [apiKey, load, snapshotName]);
+
+  const revoke = useCallback(async () => {
+    setRevoking(true);
+    setFormError(null);
+    try {
+      await revokeProviderConnection({ provider: "daytona", authMethod: "api_key" });
+      setApiKey("");
+      await load();
+    } catch {
+      setFormError("Couldn't revoke the Daytona connection.");
+    } finally {
+      setRevoking(false);
+    }
+  }, [load]);
+
+  if (error && connections.length === 0) {
+    return <BackendUnreachable onRetry={() => void load()} />;
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between gap-3 rounded-xl border border-border-button-default bg-background-secondary-default px-4 py-3">
+        <div className="flex min-w-0 items-center gap-3">
+          <RiCloudLine aria-hidden className="size-5 shrink-0 text-foreground-icon-tertiary" />
+          <div className="min-w-0">
+            <p className="text-body-2-medium text-text-primary">Managed Cube</p>
+            <p className="text-caption-1-regular text-text-tertiary">
+              Hosted sandbox runtime currently used for agent execution.
+            </p>
+          </div>
+        </div>
+        <ConnectionStatusChip status="completed">Available</ConnectionStatusChip>
+      </div>
+
+      <section className="rounded-xl border border-border-button-default bg-background-secondary-default px-4">
+        <div className="flex items-center justify-between gap-3 border-b border-separator-border py-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <RiStackLine aria-hidden className="size-4 shrink-0 text-foreground-icon-tertiary" />
+            <h3 className="text-body-medium text-text-primary">Daytona</h3>
+            <span className="truncate text-caption-1-regular text-text-tertiary">
+              Your API key and snapshot
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <ConnectionStatusChip status={connectionBadgeStatus(connection)}>
+              {statusLabel(connection)}
+            </ConnectionStatusChip>
+            <Button
+              variant="secondary"
+              size="xs"
+              className="rounded-full"
+              aria-label="Refresh Daytona connection"
+              disabled={refreshing}
+              onClick={() => void load()}
+              leadingIcon={(props) => (
+                <RiRefreshLine
+                  {...props}
+                  className={cx(props.className, refreshing && "animate-spin")}
+                />
+              )}
+            >
+              Refresh
+            </Button>
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="flex items-center gap-2 py-5 text-body-2-regular text-text-secondary">
+            <RiLoader4Line aria-hidden className="size-4 animate-spin" />
+            Loading Daytona connection...
+          </div>
+        ) : (
+          <form
+            className="flex flex-col gap-4 py-4"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void save();
+            }}
+          >
+            <div className="grid gap-3 lg:grid-cols-2">
+              <div>
+                <label
+                  className="mb-1.5 block text-caption-1-medium text-text-secondary"
+                  htmlFor="daytona-api-key"
+                >
+                  API key
+                </label>
+                <InputBase
+                  id="daytona-api-key"
+                  aria-label="Daytona API key"
+                  placeholder={connected ? MASK : "Enter your Daytona API key"}
+                  type="password"
+                  autoComplete="off"
+                  spellCheck={false}
+                  leadingIcon={RiKey2Line}
+                  value={apiKey}
+                  onChange={(event) => setApiKey(event.target.value)}
+                />
+                <p className="mt-1 text-caption-1-regular text-text-tertiary">
+                  Write-only and encrypted. Enter it again when changing the snapshot.
+                </p>
+              </div>
+              <div>
+                <label
+                  className="mb-1.5 block text-caption-1-medium text-text-secondary"
+                  htmlFor="daytona-snapshot"
+                >
+                  Snapshot name
+                </label>
+                <InputBase
+                  id="daytona-snapshot"
+                  aria-label="Daytona snapshot name"
+                  placeholder="useagent-runtime-v17"
+                  autoComplete="off"
+                  spellCheck={false}
+                  value={snapshotName}
+                  onChange={(event) => setSnapshotName(event.target.value)}
+                />
+                <p className="mt-1 text-caption-1-regular text-text-tertiary">
+                  Validated against Daytona without creating a sandbox.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-3 border-t border-separator-border pt-3 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-caption-1-regular text-text-tertiary">
+                Connection setup is available now. Personal Daytona execution remains rollout-gated.
+              </p>
+              <div className="flex items-center gap-2">
+                {connection ? (
+                  <span className="text-caption-1-regular text-text-tertiary">
+                    Updated {relTime(connection.updatedAt)}
+                  </span>
+                ) : null}
+                <Button
+                  type="button"
+                  variant="danger"
+                  size="xs"
+                  className="rounded-full"
+                  disabled={!connected || revoking}
+                  onClick={() => void revoke()}
+                >
+                  Revoke
+                </Button>
+                <Button
+                  type="submit"
+                  variant="secondary"
+                  size="small"
+                  className="rounded-full"
+                  disabled={!metadata || apiKey.trim().length === 0 || saving}
+                  leadingIcon={saving ? SpinnerIcon : undefined}
+                >
+                  {connected ? "Update Daytona" : "Connect Daytona"}
+                </Button>
+              </div>
+            </div>
+            {formError ? (
+              <p className="text-caption-1-regular text-text-error-primary">{formError}</p>
+            ) : null}
+          </form>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -1,11 +1,10 @@
-import { RiCameraLine, RiPencilLine } from "@remixicon/react";
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import { Chip } from "@/components/base/badges/chip";
-import { Button } from "@/components/base/buttons/button";
 import { AppShell } from "@/components/shell/app-shell";
 import { ThreadSidebar } from "@/components/shell/thread-sidebar";
 import { ApiKeysCard } from "./api-keys-card";
+import { DaytonaConnectionCard } from "./daytona-connection-card";
 import { GeneralCard } from "./general-card";
 import { IntegrationConnections } from "./integration-connections";
 import { ProviderConnectionsCard } from "./provider-connections-card";
@@ -14,10 +13,11 @@ import { SettingsRail } from "./settings-rail";
 import { SettingsCard, SettingsRow } from "./settings-rows";
 import { TeamCard } from "./team-card";
 import { UsageMeters } from "./usage-meters";
+import { ProviderConnectionsProvider } from "./use-provider-connections";
 
 export const metadata: Metadata = {
   title: "Settings",
-  description: "Manage your workspace, usage, machine snapshots, secrets, and team.",
+  description: "Manage your workspace, providers, infrastructure, usage, secrets, and team.",
 };
 
 /* -------------------------------------------------------------------------- */
@@ -69,112 +69,89 @@ export default function SettingsPage() {
           </aside>
 
           {/* Sections */}
-          <div className="flex min-w-0 flex-1 flex-col gap-8">
-            {/* General */}
-            <Section id="general" title="General" description="Your profile and workspace details.">
-              <GeneralCard />
-            </Section>
+          <ProviderConnectionsProvider>
+            <div className="flex min-w-0 flex-1 flex-col gap-8">
+              {/* General */}
+              <Section
+                id="general"
+                title="General"
+                description="Your profile and workspace details."
+              >
+                <GeneralCard />
+              </Section>
 
-            {/* Provider connections */}
-            <Section
-              id="providers"
-              title="Provider connections"
-              description="Your model provider accounts and write-only API keys."
-            >
-              <ProviderConnectionsCard />
-            </Section>
+              {/* Provider connections */}
+              <Section
+                id="providers"
+                title="Provider connections"
+                description="Your model provider accounts and write-only API keys."
+              >
+                <ProviderConnectionsCard />
+              </Section>
 
-            {/* Integrations */}
-            <Section
-              id="integrations"
-              title="Integrations"
-              description="Connected tools agents can use for this workspace."
-            >
-              <IntegrationConnections />
-            </Section>
+              {/* Integrations */}
+              <Section
+                id="integrations"
+                title="Integrations"
+                description="Connected tools agents can use for this workspace."
+              >
+                <IntegrationConnections />
+              </Section>
 
-            {/* Usage */}
-            <Section
-              id="usage"
-              title="Usage"
-              description="Your plan and model consumption this cycle."
-            >
-              <SettingsCard className="mb-4">
-                <SettingsRow label="Plan" description="Free while you get started.">
-                  <Chip variant="caption" color="soft">
-                    Starter - Free
-                  </Chip>
-                </SettingsRow>
-              </SettingsCard>
+              {/* Usage */}
+              <Section
+                id="usage"
+                title="Usage"
+                description="Your plan and model consumption this cycle."
+              >
+                <SettingsCard className="mb-4">
+                  <SettingsRow label="Plan" description="Free while you get started.">
+                    <Chip variant="caption" color="soft">
+                      Starter - Free
+                    </Chip>
+                  </SettingsRow>
+                </SettingsCard>
 
-              {/* Real per-model token burn from GET /api/fleet (same live source
+                {/* Real per-model token burn from GET /api/fleet (same live source
                   as the workspace Limits card). No credits meter - there is no
                   billing/credit system yet, so a fabricated "N / 2,000 credits"
                   bar was removed rather than faked. */}
-              <UsageMeters />
-            </Section>
+                <UsageMeters />
+              </Section>
 
-            {/* Machine */}
-            <Section
-              id="machine"
-              title="Machine"
-              description="The saved VM state new sessions boot from."
-            >
-              <div className="flex flex-col gap-3 rounded-xl border border-border-button-default bg-background-secondary-default p-4">
-                <div className="flex items-center gap-2">
-                  <span className="inline-flex items-center rounded-md bg-background-primary-default px-2 py-0.5 font-mono text-[0.6875rem] text-text-secondary ring-1 ring-inset ring-border-button-default">
-                    snapshot-2026-07-24
-                  </span>
-                </div>
-                <p className="text-caption-1-regular text-text-secondary">
-                  Node 24 · pnpm · Playwright
-                </p>
-                <div className="flex flex-wrap gap-2">
-                  <Button
-                    className="rounded-full"
-                    variant="secondary"
-                    size="xs"
-                    leadingIcon={RiPencilLine}
-                  >
-                    Edit machine
-                  </Button>
-                  <Button
-                    className="rounded-full"
-                    variant="primary"
-                    size="xs"
-                    leadingIcon={RiCameraLine}
-                  >
-                    New snapshot
-                  </Button>
-                </div>
-              </div>
-            </Section>
+              {/* Infrastructure */}
+              <Section
+                id="infrastructure"
+                title="Infrastructure"
+                description="View the managed runtime and connect optional sandbox accounts."
+              >
+                <DaytonaConnectionCard />
+              </Section>
 
+              {/* Secrets */}
+              <Section
+                id="secrets"
+                title="Secrets"
+                description="Persisted for every future session on this workspace."
+              >
+                <SecretsCard />
+              </Section>
 
+              {/* API keys */}
+              <Section
+                id="apikeys"
+                title="API keys"
+                description="Bearer keys that let a local script dispatch and read runs for this workspace."
+              >
+                <ApiKeysCard />
+              </Section>
 
-            {/* Secrets */}
-            <Section
-              id="secrets"
-              title="Secrets"
-              description="Persisted for every future session on this workspace."
-            >
-              <SecretsCard />
-            </Section>
-
-            {/* API keys */}
-            <Section
-              id="apikeys"
-              title="API keys"
-              description="Bearer keys that let a local script dispatch and read runs for this workspace."
-            >
-              <ApiKeysCard />
-            </Section>
-
-            {/* Team */}
-            <Section id="team" title="Team" description="People with access to this workspace.">
-              <TeamCard />
-            </Section>
-          </div>
+              {/* Team */}
+              <Section id="team" title="Team" description="People with access to this workspace.">
+                <TeamCard />
+              </Section>
+            </div>
+          </ProviderConnectionsProvider>
         </div>
       </div>
     </AppShell>

--- a/frontend/app/settings/provider-connections-card.test.ts
+++ b/frontend/app/settings/provider-connections-card.test.ts
@@ -4,9 +4,16 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { ProviderConnectionPanel } from "./provider-connection-panel";
 import { ProviderConnectionsCard } from "./provider-connections-card";
 import type { ProviderConnectionMeta } from "./provider-connections-data";
+import { ProviderConnectionsProvider } from "./use-provider-connections";
+
+function renderProviderConnectionsCard(): string {
+  return renderToStaticMarkup(
+    createElement(ProviderConnectionsProvider, null, createElement(ProviderConnectionsCard)),
+  );
+}
 
 test("renders the provider connection summary and loading state before client effects", () => {
-  const html = renderToStaticMarkup(createElement(ProviderConnectionsCard));
+  const html = renderProviderConnectionsCard();
 
   expect(html).toContain("0 of 3 providers connected");
   expect(html).toContain("Loading provider connections...");
@@ -47,4 +54,10 @@ test("renders OpenAI connected when OAuth is active and an old API key is revoke
   expect(html.slice(0, apiKeyRow)).toContain("Connected");
   expect(html.slice(0, apiKeyRow)).not.toContain("Revoked");
   expect(html.slice(apiKeyRow)).toContain("Revoked");
+});
+
+test("keeps Daytona out of the model-provider count", () => {
+  const html = renderProviderConnectionsCard();
+  expect(html).toContain("0 of 3 providers connected");
+  expect(html).not.toContain("0 of 4 providers connected");
 });

--- a/frontend/app/settings/provider-connections-card.tsx
+++ b/frontend/app/settings/provider-connections-card.tsx
@@ -7,26 +7,20 @@ import {
   RiRefreshLine,
 } from "@remixicon/react";
 import { useMemo } from "react";
-import { BackendUnreachable } from "@/components/shared/backend-unreachable";
 import { Button } from "@/components/base/buttons/button";
+import { BackendUnreachable } from "@/components/shared/backend-unreachable";
 import { cx } from "@/utils/cx";
 import { ProviderConnectionPanel } from "./provider-connection-panel";
 import {
   isActiveConnection,
-  PROVIDER_CONNECTION_PROVIDERS,
+  MODEL_PROVIDER_CONNECTION_PROVIDERS,
   providerConnectionViews,
 } from "./provider-connections-data";
 import { useProviderConnections } from "./use-provider-connections";
 
 export function ProviderConnectionsCard() {
-  const {
-    connections,
-    enabledSandboxEngines,
-    error,
-    load,
-    loading,
-    refreshing,
-  } = useProviderConnections();
+  const { connections, enabledSandboxEngines, error, load, loading, refreshing } =
+    useProviderConnections();
   const views = useMemo(() => providerConnectionViews(connections), [connections]);
   const connectedCount = views.filter(
     (view) => isActiveConnection(view.apiKey) || isActiveConnection(view.chatGptOAuth),
@@ -46,7 +40,7 @@ export function ProviderConnectionsCard() {
             <RiCloseCircleLine aria-hidden className="size-4 text-foreground-icon-tertiary" />
           )}
           <span>
-            {connectedCount} of {PROVIDER_CONNECTION_PROVIDERS.length} providers connected
+            {connectedCount} of {MODEL_PROVIDER_CONNECTION_PROVIDERS.length} providers connected
           </span>
         </div>
         <Button

--- a/frontend/app/settings/provider-connections-data.ts
+++ b/frontend/app/settings/provider-connections-data.ts
@@ -5,6 +5,7 @@
 import {
   decodeProviderConnectionMeta,
   decodeProviderConnections,
+  MODEL_PROVIDER_CONNECTION_PROVIDERS,
   PROVIDER_CONNECTION_AUTH_METHODS,
   PROVIDER_CONNECTION_PROVIDERS,
   PROVIDER_CONNECTION_STATUSES,
@@ -16,6 +17,7 @@ import {
 } from "@useagent/agent-client/provider-connections";
 
 export {
+  MODEL_PROVIDER_CONNECTION_PROVIDERS,
   PROVIDER_CONNECTION_AUTH_METHODS,
   PROVIDER_CONNECTION_PROVIDERS,
   PROVIDER_CONNECTION_STATUSES,
@@ -131,12 +133,18 @@ export const PROVIDER_LABELS: Record<
     keyHint: "OpenRouter API key",
     keyPlaceholder: "sk-or-v1-...",
   },
+  daytona: {
+    name: "Daytona",
+    scope: "Personal cloud sandbox runtime",
+    keyHint: "Daytona API key",
+    keyPlaceholder: "Daytona API key",
+  },
 };
 
 export function providerConnectionViews(
   connections: ProviderConnectionMeta[],
 ): ProviderConnectionView[] {
-  return PROVIDER_CONNECTION_PROVIDERS.map((provider) => {
+  return MODEL_PROVIDER_CONNECTION_PROVIDERS.map((provider) => {
     const providerConnections = connections.filter((item) => item.provider === provider);
     return {
       provider,
@@ -198,6 +206,20 @@ export function safeProviderMetadata(input: {
   if (email) metadata.email = email;
   if (planType) metadata.planType = planType;
   return metadata;
+}
+
+export function safeDaytonaMetadata(input: {
+  snapshotName: string;
+}): { snapshotName: string } | null {
+  const snapshotName = input.snapshotName.trim();
+  if (
+    snapshotName.length < 1 ||
+    snapshotName.length > 200 ||
+    !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(snapshotName)
+  ) {
+    return null;
+  }
+  return { snapshotName };
 }
 
 export function safeExternalAuthUrl(value: string): string | null {

--- a/frontend/app/settings/settings-rail.tsx
+++ b/frontend/app/settings/settings-rail.tsx
@@ -14,7 +14,7 @@ export const SETTINGS_SECTIONS = [
   { id: "providers", label: "Providers" },
   { id: "integrations", label: "Integrations" },
   { id: "usage", label: "Usage" },
-  { id: "machine", label: "Machine" },
+  { id: "infrastructure", label: "Infrastructure" },
   { id: "secrets", label: "Secrets" },
   { id: "apikeys", label: "API keys" },
   { id: "team", label: "Team" },

--- a/frontend/app/settings/use-provider-connections.ts
+++ b/frontend/app/settings/use-provider-connections.ts
@@ -1,14 +1,19 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
-import { useOrgChanges } from "@/hooks/use-org-changes";
 import {
-  fetchEnabledSandboxEngines,
-  fetchProviderConnections,
-} from "./provider-connections-api";
+  createContext,
+  createElement,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import { useOrgChanges } from "@/hooks/use-org-changes";
+import { fetchEnabledSandboxEngines, fetchProviderConnections } from "./provider-connections-api";
 import type { ProviderConnectionMeta } from "./provider-connections-data";
 
-export function useProviderConnections() {
+function useProviderConnectionsState() {
   const [connections, setConnections] = useState<ProviderConnectionMeta[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
@@ -52,4 +57,21 @@ export function useProviderConnections() {
     mounted,
     refreshing,
   };
+}
+
+type ProviderConnectionsState = ReturnType<typeof useProviderConnectionsState>;
+
+const ProviderConnectionsContext = createContext<ProviderConnectionsState | null>(null);
+
+export function ProviderConnectionsProvider({ children }: { readonly children: ReactNode }) {
+  const value = useProviderConnectionsState();
+  return createElement(ProviderConnectionsContext.Provider, { value }, children);
+}
+
+export function useProviderConnections(): ProviderConnectionsState {
+  const value = useContext(ProviderConnectionsContext);
+  if (!value) {
+    throw new Error("useProviderConnections requires ProviderConnectionsProvider");
+  }
+  return value;
 }

--- a/packages/agent-client/src/provider-connections.ts
+++ b/packages/agent-client/src/provider-connections.ts
@@ -1,6 +1,10 @@
 /** Browser-safe provider-connection API and realtime wire contract. */
 
-export const PROVIDER_CONNECTION_PROVIDERS = ["openai", "anthropic", "openrouter"] as const;
+export const MODEL_PROVIDER_CONNECTION_PROVIDERS = ["openai", "anthropic", "openrouter"] as const;
+export const PROVIDER_CONNECTION_PROVIDERS = [
+  ...MODEL_PROVIDER_CONNECTION_PROVIDERS,
+  "daytona",
+] as const;
 export type ProviderConnectionProvider = (typeof PROVIDER_CONNECTION_PROVIDERS)[number];
 
 export const PROVIDER_CONNECTION_AUTH_METHODS = ["chatgpt_oauth", "api_key"] as const;
@@ -15,6 +19,7 @@ export type ProviderConnectionChangeAction = (typeof PROVIDER_CONNECTION_CHANGE_
 export interface ProviderConnectionMetadata {
   readonly email?: string;
   readonly planType?: string;
+  readonly snapshotName?: string;
 }
 
 export interface ProviderConnectionMeta {
@@ -70,12 +75,19 @@ function isProviderConnectionChangeAction(value: unknown): value is ProviderConn
 
 export function decodeProviderConnectionMetadata(value: unknown): ProviderConnectionMetadata {
   if (!isRecord(value)) return {};
-  const metadata: { email?: string; planType?: string } = {};
+  const metadata: {
+    email?: string;
+    planType?: string;
+    snapshotName?: string;
+  } = {};
   if (typeof value.email === "string" && value.email.trim()) {
     metadata.email = value.email.trim();
   }
   if (typeof value.planType === "string" && value.planType.trim()) {
     metadata.planType = value.planType.trim();
+  }
+  if (typeof value.snapshotName === "string" && value.snapshotName.trim()) {
+    metadata.snapshotName = value.snapshotName.trim();
   }
   return metadata;
 }

--- a/packages/agent-client/test/provider-connections.test.ts
+++ b/packages/agent-client/test/provider-connections.test.ts
@@ -39,6 +39,23 @@ describe("provider connection wire contract", () => {
     expect(JSON.stringify(decoded)).not.toContain("credentialCiphertext");
   });
 
+  test("decodes Daytona snapshot metadata without accepting credential-shaped fields", () => {
+    const decoded = decodeProviderConnectionMeta({
+      ...connection,
+      id: "connection-daytona",
+      provider: "daytona",
+      authMethod: "api_key",
+      metadata: {
+        snapshotName: "useagent-runtime-v17",
+        apiKey: "must-drop",
+      },
+    });
+    expect(decoded?.metadata).toEqual({
+      snapshotName: "useagent-runtime-v17",
+    });
+    expect(JSON.stringify(decoded)).not.toContain("must-drop");
+  });
+
   test("rejects invalid records while preserving valid historical API rows", () => {
     const historical = {
       ...connection,


### PR DESCRIPTION
Summary
- Syncs the shared product code deployed from Pro commit 008843a0.
- Adds tenant-scoped write-only Daytona key and exact active snapshot validation in Settings.
- Keeps personal Daytona execution rollout-gated; managed Cube and current run routing are unchanged.
- Adds shared Compose release definitions and immutable release validation.
- Excludes private Hetzner deployment tooling.

Verification
- Full root TypeScript: clean.
- Fresh-database provider and Daytona: 27/27.
- Settings and shell: 32/32.
- Agent-client and Compose contracts: 6/6.
- Diff check: clean.

Production Pro deployment is healthy on 008843a0bf6b0a82150edd571d6a3145d167768f.