### PR TITLE
Fix duplicate Slack replies on resumed T3 turns

### DIFF
--- a/backend/src/engines/runtime-orchestration.test.ts
+++ b/backend/src/engines/runtime-orchestration.test.ts
@@ -686,6 +686,50 @@ describe("T3 orchestration projection", () => {
     expect(assistantText(snapshot)).toBe(exactOutput);
   });
 
+  test("never republishes a prior assistant answer while a resumed turn is starting", () => {
+    const snapshot: RuntimeThreadSnapshot = {
+      snapshotSequence: 13,
+      thread: {
+        id: "skynet-thread-thread-1",
+        latestTurn: {
+          turnId: "turn-2",
+          state: "running",
+          assistantMessageId: null,
+        },
+        messages: [
+          {
+            id: "assistant-1",
+            role: "assistant",
+            text: "prior answer must not stream into this reply",
+            turnId: "turn-1",
+            streaming: false,
+          },
+        ],
+        activities: [],
+        session: { status: "ready", lastError: null },
+      },
+    };
+
+    expect(assistantText(snapshot)).toBe("");
+
+    expect(assistantText({
+      ...snapshot,
+      thread: {
+        ...snapshot.thread,
+        messages: [
+          ...snapshot.thread.messages,
+          {
+            id: "assistant-2",
+            role: "assistant",
+            text: "current answer",
+            turnId: "turn-2",
+            streaming: true,
+          },
+        ],
+      },
+    })).toBe("current answer");
+  });
+
   test("keeps resumed-turn provider events on the product thread and current run", () => {
     expect(runtimeActivityProviderEvent(
       { runId: "run-2", threadId: "thread-1" },

--- a/backend/src/engines/runtime-orchestration.ts
+++ b/backend/src/engines/runtime-orchestration.ts
@@ -467,12 +467,18 @@ export function isRuntimeThreadSessionId(sessionId: string): boolean {
 }
 
 export function assistantText(snapshot: RuntimeThreadSnapshot): string {
-  const messageId = snapshot.thread.latestTurn?.assistantMessageId;
+  const latestTurn = snapshot.thread.latestTurn;
+  if (!latestTurn) return "";
+  const messageId = latestTurn.assistantMessageId;
   const matching = messageId
     ? snapshot.thread.messages.find((message) => message.id === messageId)
     : undefined;
-  if (matching?.role === "assistant") return matching.text;
-  return snapshot.thread.messages.findLast((message) => message.role === "assistant")?.text ?? "";
+  if (matching?.role === "assistant" && matching.turnId === latestTurn.turnId) {
+    return matching.text;
+  }
+  return snapshot.thread.messages.findLast(
+    (message) => message.role === "assistant" && message.turnId === latestTurn.turnId,
+  )?.text ?? "";
 }
 
 const TRANSPORT_PLACEHOLDER_LABELS = new Set([


### PR DESCRIPTION
Production root cause
When a resumed T3 turn temporarily had no assistantMessageId, assistantText fell back to the previous turn's last assistant message. That old answer was emitted as the new run's live Slack/SSE narration.

Fix
- Resolve assistant output only within latestTurn.
- Require matching turnId for referenced and fallback messages.
- Preserve delayed current-turn messages without cross-turn fallback.

Verification
- Runtime orchestration and adapter: 51/51.
- Backend TypeScript: clean.
- Production two-turn canary: turn two Slack payload contained only NARRATION_TWO_831 and did not contain NARRATION_ONE_831.

Deployed Pro commit: 1595a4334ae95e3ad8928039b6429ebcba19b845.