### PR TITLE
Restore Slack native stream and artifact follow-ups

### DIFF
--- a/backend/src/slack/client.test.ts
+++ b/backend/src/slack/client.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { httpSlackClient } from "./client";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("Slack streaming wire contract", () => {
+  test("append and stop address the stream by Slack's required ts field", async () => {
+    const requests: Array<{ url: string; body: Record<string, unknown> }> = [];
+    globalThis.fetch = (async (input, init) => {
+      requests.push({
+        url: String(input),
+        body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>,
+      });
+      return new Response(JSON.stringify({ ok: true, ts: "1717171717.999999" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const client = httpSlackClient({ botToken: "xoxb-test", apiUrl: "https://slack.test/api/" });
+    await client.appendStream({
+      channel: "C123",
+      threadTs: "1717171717.000001",
+      messageTs: "1717171717.999999",
+      chunks: [{ type: "markdown_text", text: "working" }],
+    });
+    await client.stopStream({
+      channel: "C123",
+      threadTs: "1717171717.000001",
+      messageTs: "1717171717.999999",
+      chunks: [{ type: "task_update", id: "run", title: "Done", status: "complete" }],
+    });
+
+    expect(requests).toHaveLength(2);
+    expect(requests[0]).toEqual({
+      url: "https://slack.test/api/chat.appendStream",
+      body: {
+        channel: "C123",
+        thread_ts: "1717171717.000001",
+        ts: "1717171717.999999",
+        chunks: [{ type: "markdown_text", text: "working" }],
+      },
+    });
+    expect(requests[1]).toEqual({
+      url: "https://slack.test/api/chat.stopStream",
+      body: {
+        channel: "C123",
+        thread_ts: "1717171717.000001",
+        ts: "1717171717.999999",
+        chunks: [{ type: "task_update", id: "run", title: "Done", status: "complete" }],
+      },
+    });
+    expect(requests.some((request) => "message_ts" in request.body)).toBeFalse();
+  });
+});

--- a/backend/src/slack/client.ts
+++ b/backend/src/slack/client.ts
@@ -220,14 +220,14 @@ export function httpSlackClient(config: SlackClientConfig): SlackClient {
       call("chat.appendStream", {
         channel,
         thread_ts: threadTs,
-        message_ts: messageTs,
+        ts: messageTs,
         chunks,
       }),
     stopStream: ({ channel, threadTs, messageTs, chunks, blocks }) =>
       call("chat.stopStream", {
         channel,
         thread_ts: threadTs,
-        message_ts: messageTs,
+        ts: messageTs,
         chunks,
         ...(blocks ? { blocks } : {}),
       }),

--- a/backend/src/slack/events.ts
+++ b/backend/src/slack/events.ts
@@ -1,7 +1,7 @@
 /**
  * Slack Events-API ingest, adapted to the runs model. Given a verified
- * `event_callback` envelope, this resolves the workspace to a tenant identity
- * (fail closed), decides whether the message is for us, stages inbound
+ * `event_callback` envelope plus the immutable identity captured by the durable
+ * inbox, this decides whether the message is for us, stages inbound
  * attachments, maps it onto a run (root or `parent_run_id` reply), 👀-acks, and
  * registers a completion watcher. Kept deliberately small — QM's turn-handler
  * (approvals, reactions, mirroring, agent-requests) is DEFERRED.
@@ -28,7 +28,6 @@ import { pumpThread } from "../worker";
 import { stageInboundSlackFiles, type SlackInboundFileMeta } from "./inbound-files";
 import { createSlackRunResponse, findOrAdoptSlackThread, linkSlackThread } from "./repo";
 import { watchSlackRun } from "./watcher";
-import { resolveSlackSender, resolveSlackWorkspace } from "./workspaces";
 import {
   enqueueAddReactionTx,
   enqueuePostMessage,
@@ -58,33 +57,9 @@ import {
 } from "../resources/run-intake";
 import { resolveSlackBotTokenForWorkspace } from "../integrations/slack-token-resolver";
 
-// Bounded FIFO deduper — collapses Slack retries AND the app_mention/message
-// pair for a channel mention (both carry the same `channel:ts`). No LRU dep;
-// a Set is insertion-ordered so the oldest key evicts first.
-function createDeduper(max = 1000): { seen(key: string): boolean; forget(key: string): void } {
-  const set = new Set<string>();
-  return {
-    seen(key) {
-      if (set.has(key)) return true;
-      set.add(key);
-      if (set.size > max) {
-        const oldest = set.values().next().value;
-        if (oldest !== undefined) set.delete(oldest);
-      }
-      return false;
-    },
-    forget(key) {
-      set.delete(key);
-    },
-  };
-}
-
-let deduper = createDeduper();
-
-/** TEST ONLY: drop all in-memory dedupe state, simulating a process restart so
- *  suites can prove the DURABLE dedupe (the command-lane idempotency key). */
+/** Compatibility no-op: ingress dedupe now lives in the durable Slack inbox. */
 export function resetSlackDeduperForTest(): void {
-  deduper = createDeduper();
+  // Intentionally empty.
 }
 
 const TERMINAL_STATUSES = new Set<RunStatus>(["completed", "failed"]);
@@ -211,38 +186,108 @@ function cleanPrompt(text: string, botUserId: string): string {
   return t.replace(/\s+/g, " ").trim();
 }
 
-/**
- * Process a verified `event_callback`. Runs ASYNC behind the transport ack
- * (both the HTTP route and Socket Mode ack first, then hand the envelope here),
- * so run acceptance, attachment staging, and outbound calls never eat into
- * Slack's 3s ack budget.
- */
-export async function handleSlackEvent(body: SlackEnvelope): Promise<void> {
+/** Pure transport-envelope gates that never need tenant identity or mutation. */
+export function slackEventIsEarlyNoop(body: SlackEnvelope): boolean {
   const config = slackConfig();
-  if (!config) return;
+  if (!config) return true;
+  const event = body.event;
+  const type = event?.type;
+  if (!event || (type !== "app_mention" && type !== "message")) return true;
+  if (event.bot_id) return true;
+  const botUserId = botUserIdOf(body);
+  if (botUserId && event.user === botUserId) return true;
+  if (type === "message" && event.subtype && event.subtype !== "file_share") return true;
+  const channel = event.channel;
+  const ts = event.ts;
+  if (!channel || !ts || !body.team_id) return true;
+  if (config.channelAllowlist.size > 0 && !config.channelAllowlist.has(channel)) return true;
+  if (event.channel_type === "im" || type !== "message") return false;
+  const rawText = typeof event.text === "string" ? event.text : "";
+  const isMention = botUserId ? rawText.includes(`<@${botUserId}>`) : false;
+  const isThreadReply = Boolean(event.thread_ts && event.thread_ts !== ts);
+  return isMention || !isThreadReply;
+}
+
+export interface SlackEventHandlingOptions {
+  /** Immutable tenant identity captured before the transport ACK. */
+  readonly identity: { readonly orgId: string; readonly actorId: string | null };
+  /** null/undefined means file staging has not run; an array means reuse its
+   * exact result so a close-vs-accept race never redownloads attachments. */
+  readonly stagedAttachmentIds?: readonly string[] | null;
+  /** Persist staging progress into the fenced inbox claim before acceptance. */
+  readonly checkpointStagedAttachmentIds?: (ids: readonly string[]) => Promise<void>;
+}
+
+export type SlackEventOutcome =
+  | { readonly status: "accepted"; readonly runId: string }
+  | { readonly status: "replayed"; readonly runId: string }
+  | { readonly status: "permanent_noop"; readonly reason: string }
+  | { readonly status: "retryable_unavailable"; readonly reason: string }
+  | { readonly status: "waiting_for_root"; readonly threadTs: string };
+
+async function handleAdmissionClosed(input: {
+  readonly error: RunAdmissionClosedError;
+  readonly teamId: string;
+  readonly channel: string;
+  readonly ts: string;
+  readonly threadTs: string;
+}): Promise<SlackEventOutcome> {
+  await enqueuePostMessage({
+    idempotencyKey: `slack-admission-queued:${input.teamId}:${input.channel}:${input.ts}`,
+    teamId: input.teamId,
+    channel: input.channel,
+    threadTs: input.threadTs,
+    text: "Your request is queued during the deployment and will start automatically when service resumes.",
+  });
+  return { status: "retryable_unavailable", reason: input.error.code };
+}
+
+/**
+ * Process one durably accepted inbox event. Transports invoke this only through
+ * the inbox pump after persistence has succeeded and the ACK has been sent.
+ */
+export async function handleSlackEvent(
+  body: SlackEnvelope,
+  options: SlackEventHandlingOptions,
+): Promise<SlackEventOutcome> {
+  if (slackEventIsEarlyNoop(body)) {
+    return { status: "permanent_noop", reason: "early_envelope_gate" };
+  }
+  const config = slackConfig();
+  if (!config) return { status: "retryable_unavailable", reason: "slack_not_configured" };
 
   const event = body.event;
   const type = event?.type;
-  if (!event || (type !== "app_mention" && type !== "message")) return;
+  if (!event || (type !== "app_mention" && type !== "message")) {
+    return { status: "permanent_noop", reason: "unsupported_event" };
+  }
 
   // Never react to bot-authored messages (loop guard) or non-plain message
   // subtypes (edits/deletes/joins — deferred). `file_share` is the one subtype
   // let through: it is how a plain message with attachments arrives.
-  if (event.bot_id) return;
+  if (event.bot_id) return { status: "permanent_noop", reason: "bot_message" };
   const botUserId = botUserIdOf(body);
-  if (botUserId && event.user === botUserId) return;
-  if (type === "message" && event.subtype && event.subtype !== "file_share") return;
+  if (botUserId && event.user === botUserId) {
+    return { status: "permanent_noop", reason: "self_message" };
+  }
+  if (type === "message" && event.subtype && event.subtype !== "file_share") {
+    return { status: "permanent_noop", reason: "unsupported_message_subtype" };
+  }
 
   const channel = event.channel;
   const ts = event.ts;
   const teamId = body.team_id;
-  if (!channel || !ts || !teamId) return;
+  if (!channel || !ts || !teamId) {
+    return { status: "permanent_noop", reason: "missing_message_identity" };
+  }
 
   // Operator channel allowlist: when set, ONLY events from listed channel ids
   // are processed (DMs included - a DM channel id is not in the list). Keeps a
   // freshly connected workspace scoped to a designated test channel until the
   // adapter is opened up.
-  if (config.channelAllowlist.size > 0 && !config.channelAllowlist.has(channel)) return;
+  if (config.channelAllowlist.size > 0 && !config.channelAllowlist.has(channel)) {
+    return { status: "permanent_noop", reason: "channel_not_allowed" };
+  }
 
   const rawText = typeof event.text === "string" ? event.text : "";
   const threadTs = typeof event.thread_ts === "string" ? event.thread_ts : undefined;
@@ -252,23 +297,17 @@ export async function handleSlackEvent(body: SlackEnvelope): Promise<void> {
 
   // Gating for non-DM plain `message` events.
   if (!isDm && type === "message") {
-    if (isMention) return; // the paired app_mention handles it
-    if (!isThreadReply) return; // untargeted channel chatter
+    if (isMention) return { status: "permanent_noop", reason: "paired_message_event" };
+    if (!isThreadReply) return { status: "permanent_noop", reason: "untargeted_channel_message" };
   }
 
-  // Workspace identity — FAIL CLOSED. An event from a workspace with no
-  // slack_workspaces mapping is ignored (logged once per team id); nothing ever
-  // falls back to a seeded org. Resolved BEFORE dedupe so an unmapped
-  // workspace's event never reserves a dedupe key (a retry after the operator
-  // adds the mapping still lands).
-  const workspace = await resolveSlackWorkspace(teamId);
-  if (!workspace) return;
+  const orgId = options.identity.orgId;
   const botToken = await resolveSlackBotTokenForWorkspace({
-    orgId: workspace.orgId,
+    orgId,
     teamId,
     config,
   });
-  if (!botToken) return;
+  if (!botToken) return { status: "retryable_unavailable", reason: "bot_token_unavailable" };
 
   // A message threads under its thread root (replies) or under itself (top-level).
   const slackThreadTs = threadTs ?? ts;
@@ -276,16 +315,18 @@ export async function handleSlackEvent(body: SlackEnvelope): Promise<void> {
     teamId,
     channel,
     threadTs: slackThreadTs,
-    orgId: workspace.orgId,
+    orgId,
   });
-  if (!isDm && type === "message" && isThreadReply && !link) return;
+  if (!isDm && type === "message" && isThreadReply && !link) {
+    return { status: "waiting_for_root", threadTs: slackThreadTs };
+  }
 
   // Workspace mapping establishes the tenant only. Every run also receives org
   // memory, provider access, and sandbox secrets, so an unmapped sender cannot
   // safely run even an apparently "org-only" prompt. Require the explicit
   // per-Slack-user mapping before dedupe or any durable work.
-  const sender = await resolveSlackSender(workspace, teamId, event.user);
-  if (!sender) {
+  const userId = options.identity.actorId;
+  if (!userId) {
     await enqueuePostMessage({
       idempotencyKey: `slack-sender-guidance:${teamId}:${channel}:${ts}`,
       teamId,
@@ -293,19 +334,10 @@ export async function handleSlackEvent(body: SlackEnvelope): Promise<void> {
       threadTs: slackThreadTs,
       text: "Your Slack user is not linked to a product account. Ask an operator to add a SLACK_USER_BINDINGS mapping and retry.",
     });
-    return;
+    return { status: "permanent_noop", reason: "sender_not_linked" };
   }
 
-  // Dedupe last, so a genuinely-ours message reserves its key exactly once.
-  const key = `${teamId}:${channel}:${ts}`;
-  if (deduper.seen(key)) return;
-
-  const orgId = workspace.orgId;
-  const userId = sender.userId;
-
-  const durableKey = body.event_id
-    ? `slack-event:${teamId}:${body.event_id}`
-    : `slack-event:${teamId}:${channel}:${ts}`;
+  const durableKey = `slack-event:${teamId}:${channel}:${ts}`;
   const files = Array.isArray(event.files) ? event.files : [];
 
   let prompt = cleanPrompt(rawText, botUserId);
@@ -313,8 +345,7 @@ export async function handleSlackEvent(body: SlackEnvelope): Promise<void> {
     // A files-only message still runs (the attachments ARE the request); an
     // empty message with no attached files stays a no-op.
     if (files.length === 0) {
-      deduper.forget(key);
-      return;
+      return { status: "permanent_noop", reason: "empty_message" };
     }
     prompt = "Review the attached files.";
   }
@@ -360,7 +391,7 @@ export async function handleSlackEvent(body: SlackEnvelope): Promise<void> {
           threadTs: slackThreadTs,
           text: "This thread uses personal resources and your Slack user is not linked to its owner. Link the sender identity or start a new org-scoped thread.",
         });
-        return;
+        return { status: "permanent_noop", reason: "personal_thread_owner_mismatch" };
       }
     }
   }
@@ -382,16 +413,16 @@ export async function handleSlackEvent(body: SlackEnvelope): Promise<void> {
     if (rest) prompt = rest;
     else if (files.length === 0) {
       await guide("Include your request in the same message as the directive, e.g. `model:sol summarize this thread`.");
-      return;
+      return { status: "permanent_noop", reason: "directive_without_prompt" };
     }
     if (directives.engine) {
       if (!isSlackSwitchableEngine(directives.engine)) {
         await guide(`Unknown engine \`${directives.engine}\`. Available: opencode, claude, codex.`);
-        return;
+        return { status: "permanent_noop", reason: "unknown_engine_directive" };
       }
       if (parent && directives.engine !== engine) {
         await guide(`This thread runs on \`${engine}\` and cannot switch engines mid-thread. Start a new thread to use \`${directives.engine}\`.`);
-        return;
+        return { status: "permanent_noop", reason: "cross_engine_thread_switch" };
       }
       if (!parent && directives.engine !== engine) {
         engine = directives.engine;
@@ -402,7 +433,7 @@ export async function handleSlackEvent(body: SlackEnvelope): Promise<void> {
       const resolved = resolveModelToken(engine, directives.model);
       if (!resolved) {
         await guide(`Unknown model \`${directives.model}\` for \`${engine}\`. Available: ${modelCatalogLine(engine)}.`);
-        return;
+        return { status: "permanent_noop", reason: "unknown_model_directive" };
       }
       model = resolved;
     }
@@ -445,15 +476,13 @@ export async function handleSlackEvent(body: SlackEnvelope): Promise<void> {
     });
   } catch (error) {
     if (!(error instanceof RunAdmissionClosedError)) throw error;
-    deduper.forget(key);
-    await enqueuePostMessage({
-      idempotencyKey: `slack-admission-guidance:${teamId}:${channel}:${ts}`,
+    return handleAdmissionClosed({
+      error,
       teamId,
       channel,
+      ts,
       threadTs: slackThreadTs,
-      text: "New runs are temporarily paused for a deployment. Retry this message shortly.",
     });
-    return;
   }
   if (replay) {
     if (replay.status === "replayed" && !link) {
@@ -469,14 +498,28 @@ export async function handleSlackEvent(body: SlackEnvelope): Promise<void> {
       await healSlackRunDelivery({ runId: replay.runId, teamId, channel, threadTs: slackThreadTs, messageTs: ts, slackUserId: event.user });
     }
     console.log(`[slack] duplicate event ignored (${replay.status}): ${durableKey}`);
-    return;
+    return replay.status === "replayed"
+      ? { status: "replayed", runId: replay.runId }
+      : {
+          status: "permanent_noop",
+          reason: replay.status === "conflict" ? `run_replay_${replay.reason}` : "unexpected_replay_state",
+        };
   }
 
   // Only a first acceptance downloads and stages Slack files. A lost-response
   // retry above uses Slack's stable file identity and never touches the CDN.
-  const attachmentIds = files.length > 0
-    ? await stageInboundSlackFiles({ files, botToken, orgId, userId })
-    : [];
+  const attachmentIds = options.stagedAttachmentIds != null
+    ? [...options.stagedAttachmentIds]
+    : files.length > 0
+      ? await stageInboundSlackFiles({ files, botToken, orgId, userId })
+      : [];
+  if (
+    files.length > 0 &&
+    options.stagedAttachmentIds == null &&
+    options.checkpointStagedAttachmentIds
+  ) {
+    await options.checkpointStagedAttachmentIds(attachmentIds);
+  }
 
   let resources: readonly RunResource[];
   let boundRepos: string[];
@@ -513,13 +556,12 @@ export async function handleSlackEvent(body: SlackEnvelope): Promise<void> {
       threadTs: slackThreadTs,
       text: `${error.diagnostic.message} ${error.diagnostic.action}`,
     });
-    return;
+    return { status: "permanent_noop", reason: "resource_intake_rejected" };
   }
 
-  // Enter through the durable command lane keyed by the SLACK EVENT IDENTITY
-  // (event_id when present - retries reuse it - else channel:ts), so a
-  // duplicate delivery that outlives the in-memory deduper (restart, cross-lane
-  // HTTP+socket double delivery) still collapses to ONE run. The mailbox pump
+  // Enter through the durable command lane keyed by the Slack MESSAGE identity
+  // (team + channel + ts), so transport retries or two delivery IDs for the
+  // same message still collapse to ONE run. The mailbox pump
   // preserves per-thread order: a reply in an active Slack thread waits for the
   // prior turn.
   let outcome;
@@ -556,15 +598,13 @@ export async function handleSlackEvent(body: SlackEnvelope): Promise<void> {
     });
   } catch (error) {
     if (!(error instanceof RunAdmissionClosedError)) throw error;
-    deduper.forget(key);
-    await enqueuePostMessage({
-      idempotencyKey: `slack-admission-guidance:${teamId}:${channel}:${ts}`,
+    return handleAdmissionClosed({
+      error,
       teamId,
       channel,
+      ts,
       threadTs: slackThreadTs,
-      text: "New runs are temporarily paused for a deployment. Retry this message shortly.",
     });
-    return;
   }
 
   // A durable duplicate (the in-memory fast path missed it - restart or
@@ -581,7 +621,9 @@ export async function handleSlackEvent(body: SlackEnvelope): Promise<void> {
       await healSlackRunDelivery({ runId: outcome.runId, teamId, channel, threadTs: slackThreadTs, messageTs: ts, slackUserId: event.user });
     }
     console.log(`[slack] duplicate event ignored (${outcome.status}): ${durableKey}`);
-    return;
+    return outcome.status === "replayed"
+      ? { status: "replayed", runId: outcome.runId }
+      : { status: "permanent_noop", reason: `run_accept_${outcome.reason}` };
   }
 
   // First bot interaction in this Slack thread → remember it as the root. Linked
@@ -595,4 +637,5 @@ export async function handleSlackEvent(body: SlackEnvelope): Promise<void> {
   await pumpThread(threadId);
 
   watchSlackRun({ runId, rootRunId: threadId, teamId, channel, threadTs: slackThreadTs });
+  return { status: "accepted", runId };
 }

--- a/backend/src/slack/inbox.ts
+++ b/backend/src/slack/inbox.ts
@@ -1,0 +1,698 @@
+import { and, eq, isNull, sql } from "drizzle-orm";
+import { db } from "../db/client";
+import { commands, type CommandState } from "../db/schema";
+import type { SlackEnvelope } from "./events";
+import { MAX_INBOUND_SLACK_FILES } from "./inbound-files";
+import { findSlackUser, findSlackWorkspace } from "./workspaces";
+import { findSlackThread } from "./repo";
+
+export const SLACK_INBOX_EVENT = "slack.inbox.event" as const;
+const INBOX_KEY_PREFIX = "slack-inbox:";
+const MAX_PAYLOAD_BYTES = 1_000_000;
+const MAX_ATTEMPTS = 8;
+const CLAIM_LIMIT = 10;
+const STALE_CLAIM_SECONDS = 30;
+const PUMP_INTERVAL_MS = 250;
+const CLAIM_HEARTBEAT_MS = 10_000;
+const TERMINAL_REDACT_AFTER_SECONDS = 24 * 60 * 60;
+const TERMINAL_DELETE_AFTER_SECONDS = 7 * 24 * 60 * 60;
+const RETENTION_BATCH = 100;
+const RETENTION_INTERVAL_MS = 60_000;
+const MAX_TEXT_CHARS = 80_000;
+const MAX_METADATA_CHARS = 4_096;
+const DEFER_BASE_MS = 1_000;
+const DEFER_MAX_MS = 60_000;
+const DEFER_MAX_COUNT = 20;
+const DEFER_EXPIRE_MS = 30 * 60 * 1000;
+const ROOT_PROBATION_BASE_MS = 250;
+const ROOT_PROBATION_MAX_MS = 5_000;
+const ROOT_PROBATION_MAX_COUNT = 12;
+const ROOT_PROBATION_EXPIRE_MS = 2 * 60 * 1000;
+
+export interface SlackInboxIdentity {
+  readonly teamId: string | null;
+  readonly channel: string | null;
+  readonly messageTs: string | null;
+  readonly eventId: string | null;
+  readonly slackUserId: string | null;
+  readonly orgId: string | null;
+  readonly actorId: string | null;
+}
+
+export interface SlackInboxPayload {
+  readonly schema: 1;
+  readonly envelope: SlackEnvelope;
+  readonly identity: SlackInboxIdentity;
+  /** null means file staging has not run; an array (even empty) means its exact
+   * result was checkpointed and must be reused. */
+  readonly stagedAttachmentIds: readonly string[] | null;
+  readonly defer: {
+    readonly reason: string;
+    readonly count: number;
+    readonly firstDeferredAt: string;
+    readonly nextAttemptAt: string;
+  } | null;
+}
+
+interface ClaimedSlackInboxEvent {
+  readonly id: string;
+  readonly payload: string;
+  readonly attemptCount: number;
+  readonly claimToken: string;
+}
+
+export interface SlackInboxClaim {
+  readonly payload: SlackInboxPayload;
+  readonly checkpointStagedAttachmentIds: (ids: readonly string[]) => Promise<void>;
+}
+
+export type SlackInboxOutcome =
+  | { readonly status: "completed" }
+  | { readonly status: "retryable_unavailable"; readonly error: string }
+  | { readonly status: "waiting_for_root" }
+  | { readonly status: "permanent"; readonly error: string };
+
+export type SlackInboxHandler = (claim: SlackInboxClaim) => Promise<SlackInboxOutcome>;
+
+export class StaleSlackInboxClaimError extends Error {
+  constructor() {
+    super("Slack inbox claim is no longer current");
+    this.name = "StaleSlackInboxClaimError";
+  }
+}
+
+function hash(value: string): string {
+  return new Bun.CryptoHasher("sha256").update(value).digest("hex");
+}
+
+function boundedString(value: unknown, max: number, field: string): string | undefined {
+  if (typeof value !== "string") return undefined;
+  if (value.length > max) throw new Error(`Slack inbox ${field} exceeds ${max} characters`);
+  return value;
+}
+
+/** Strip provider-added fields and retain only the data the Slack adapter uses. */
+export function canonicalizeSlackEnvelope(envelope: SlackEnvelope): SlackEnvelope {
+  const event = envelope.event;
+  return {
+    type: boundedString(envelope.type, 64, "type"),
+    event_id: boundedString(envelope.event_id, 256, "event_id"),
+    team_id: boundedString(envelope.team_id, 256, "team_id"),
+    authorizations: envelope.authorizations?.slice(0, 1).map((authorization) => ({
+      user_id: boundedString(authorization.user_id, 256, "authorization.user_id"),
+    })),
+    ...(event ? {
+      event: {
+        type: boundedString(event.type, 64, "event.type"),
+        subtype: boundedString(event.subtype, 64, "event.subtype"),
+        channel: boundedString(event.channel, 256, "event.channel"),
+        channel_type: boundedString(event.channel_type, 64, "event.channel_type"),
+        user: boundedString(event.user, 256, "event.user"),
+        bot_id: boundedString(event.bot_id, 256, "event.bot_id"),
+        text: boundedString(event.text, MAX_TEXT_CHARS, "event.text"),
+        ts: boundedString(event.ts, 256, "event.ts"),
+        thread_ts: boundedString(event.thread_ts, 256, "event.thread_ts"),
+        files: event.files?.slice(0, MAX_INBOUND_SLACK_FILES).map((file) => ({
+          id: boundedString(file.id, 256, "file.id"),
+          name: boundedString(file.name, MAX_METADATA_CHARS, "file.name"),
+          size: typeof file.size === "number" && Number.isFinite(file.size) ? file.size : undefined,
+          mimetype: boundedString(file.mimetype, 512, "file.mimetype"),
+          url_private_download: boundedString(
+            file.url_private_download,
+            MAX_METADATA_CHARS,
+            "file.url_private_download",
+          ),
+          url_private: boundedString(file.url_private, MAX_METADATA_CHARS, "file.url_private"),
+        })),
+      },
+    } : {}),
+  };
+}
+
+export function slackInboxKey(envelope: SlackEnvelope): string {
+  const teamId = envelope.team_id?.trim() || "missing-team";
+  const channel = envelope.event?.channel?.trim();
+  const ts = envelope.event?.ts?.trim();
+  const eventId = envelope.event_id?.trim();
+  // Slack retries preserve event_id. Channel/message time is the fallback for
+  // legacy envelopes that omit it; run acceptance separately uses channel:ts
+  // so two delivery IDs for one message still cannot mint two runs.
+  const identity = eventId || (channel && ts ? `${channel}:${ts}` : hash(JSON.stringify(envelope)));
+  return `${INBOX_KEY_PREFIX}${teamId}:${identity}`;
+}
+
+function ordinaryChannelThreadReply(envelope: SlackEnvelope): {
+  teamId: string;
+  channel: string;
+  threadTs: string;
+} | null {
+  const event = envelope.event;
+  if (
+    event?.type !== "message" ||
+    event.channel_type === "im" ||
+    !envelope.team_id ||
+    !event.channel ||
+    !event.ts ||
+    !event.thread_ts ||
+    event.thread_ts === event.ts
+  ) {
+    return null;
+  }
+  return { teamId: envelope.team_id, channel: event.channel, threadTs: event.thread_ts };
+}
+
+export type SlackInboxPersistDecision = "drop" | "persist" | "awaiting_root_commit";
+
+/**
+ * DB-backed classification for ordinary channel replies after the pure gate.
+ * A valid mapped workspace reply whose root is not visible yet is never ACK-
+ * dropped: root and reply HTTP/Socket deliveries can commit in either order.
+ */
+export async function classifySlackInboxEvent(
+  envelope: SlackEnvelope,
+): Promise<SlackInboxPersistDecision> {
+  const reply = ordinaryChannelThreadReply(envelope);
+  if (!reply) return "persist";
+  const [workspace, exact, legacy] = await Promise.all([
+    findSlackWorkspace(reply.teamId),
+    findSlackThread(reply.teamId, reply.channel, reply.threadTs),
+    findSlackThread("__legacy__", reply.channel, reply.threadTs),
+  ]);
+  if (!workspace) return "drop";
+  if (exact) return exact.orgId === workspace.orgId ? "persist" : "drop";
+  if (legacy) return legacy.orgId === workspace.orgId ? "persist" : "drop";
+  return "awaiting_root_commit";
+}
+
+/** Existing indexed commands.thread_id representation of a Slack root thread. */
+export function slackInboxThreadId(envelope: SlackEnvelope): string | null {
+  const teamId = envelope.team_id?.trim();
+  const channel = envelope.event?.channel?.trim();
+  const threadTs = envelope.event?.thread_ts?.trim() || envelope.event?.ts?.trim();
+  if (!teamId || !channel || !threadTs) return null;
+  return `slack-inbox-thread:${hash(JSON.stringify([teamId, channel, threadTs]))}`;
+}
+
+async function resolveIngressIdentity(envelope: SlackEnvelope): Promise<SlackInboxIdentity> {
+  const teamId = envelope.team_id?.trim() || null;
+  const slackUserId = envelope.event?.user?.trim() || null;
+  const workspace = teamId ? await findSlackWorkspace(teamId) : null;
+  const sender = workspace && teamId && slackUserId
+    ? await findSlackUser(teamId, slackUserId)
+    : null;
+  return {
+    teamId,
+    channel: envelope.event?.channel?.trim() || null,
+    messageTs: envelope.event?.ts?.trim() || null,
+    eventId: envelope.event_id?.trim() || null,
+    slackUserId,
+    orgId: workspace?.orgId ?? null,
+    actorId: sender?.orgId === workspace?.orgId ? sender?.userId ?? null : null,
+  };
+}
+
+function serializePayload(payload: SlackInboxPayload): string {
+  const raw = JSON.stringify(payload);
+  if (Buffer.byteLength(raw, "utf8") > MAX_PAYLOAD_BYTES) {
+    throw new Error(`Slack inbox payload exceeds ${MAX_PAYLOAD_BYTES} bytes`);
+  }
+  return raw;
+}
+
+type PersistOverride = (envelope: SlackEnvelope) => Promise<"created" | "duplicate">;
+let persistOverride: PersistOverride | null = null;
+type BeforePersistInsertOverride = (envelope: SlackEnvelope) => Promise<void>;
+let beforePersistInsertOverride: BeforePersistInsertOverride | null = null;
+
+/** Test-only fault injection at the transport durability boundary. */
+export function setSlackInboxPersisterForTest(override: PersistOverride | null): void {
+  persistOverride = override;
+}
+
+/** Test-only barrier immediately before the durable INSERT. */
+export function setSlackInboxBeforePersistInsertForTest(
+  override: BeforePersistInsertOverride | null,
+): void {
+  beforePersistInsertOverride = override;
+}
+
+/** Resolve immutable tenant identity and durably record a verified event. */
+export async function persistSlackInboxEvent(
+  envelope: SlackEnvelope,
+  decision: Exclude<SlackInboxPersistDecision, "drop"> = "persist",
+): Promise<"created" | "duplicate"> {
+  if (persistOverride) return persistOverride(envelope);
+  const canonicalEnvelope = canonicalizeSlackEnvelope(envelope);
+  const identity = await resolveIngressIdentity(canonicalEnvelope);
+  const semanticPayload: SlackInboxPayload = {
+    schema: 1,
+    envelope: canonicalEnvelope,
+    identity,
+    stagedAttachmentIds: null,
+    defer: null,
+  };
+  const now = Date.now();
+  const payload = serializePayload(decision === "awaiting_root_commit"
+    ? {
+        ...semanticPayload,
+        defer: {
+          reason: "awaiting_root_commit",
+          count: 0,
+          firstDeferredAt: new Date(now).toISOString(),
+          nextAttemptAt: new Date(now + ROOT_PROBATION_BASE_MS).toISOString(),
+        },
+      }
+    : semanticPayload);
+  const id = slackInboxKey(canonicalEnvelope);
+  // Probation timing is mutable retry state, not provider-event identity.
+  const payloadFingerprint = hash(serializePayload(semanticPayload));
+  await beforePersistInsertOverride?.(canonicalEnvelope);
+  const inserted = await db
+    .insert(commands)
+    .values({
+      id,
+      idempotencyKey: id,
+      orgId: identity.orgId,
+      actorId: identity.actorId,
+      kind: SLACK_INBOX_EVENT,
+      threadId: slackInboxThreadId(canonicalEnvelope),
+      payload,
+      payloadFingerprint,
+      state: "queued" satisfies CommandState,
+      attemptCount: 0,
+    })
+    .onConflictDoNothing({ target: commands.id })
+    .returning({ id: commands.id });
+  if (inserted.length > 0) {
+    kickSlackInbox();
+    return "created";
+  }
+  const [existing] = await db
+    .select({ fingerprint: commands.payloadFingerprint, kind: commands.kind })
+    .from(commands)
+    .where(eq(commands.id, id))
+    .limit(1);
+  if (!existing || existing.kind !== SLACK_INBOX_EVENT || existing.fingerprint !== payloadFingerprint) {
+    throw new Error("Slack inbox identity was reused with a different payload");
+  }
+  // A later provider retry may be the only chance to heal a crash after run
+  // acceptance but before Slack thread/outbox linkage. Re-open only successful
+  // rows; permanent identity/payload failures remain failed closed.
+  await db
+    .update(commands)
+    .set({ payload, state: "queued", attemptCount: 0, error: null, updatedAt: new Date() })
+    .where(and(
+      eq(commands.id, id),
+      eq(commands.state, "completed"),
+      isNull(commands.error),
+    ));
+  kickSlackInbox();
+  return "duplicate";
+}
+
+function parsePayload(raw: unknown): SlackInboxPayload {
+  if (typeof raw !== "string") throw new Error("invalid Slack inbox payload");
+  const parsed = JSON.parse(raw) as Partial<SlackInboxPayload>;
+  if (parsed.schema !== 1 || !parsed.envelope || !parsed.identity) {
+    throw new Error("invalid Slack inbox payload");
+  }
+  if (parsed.stagedAttachmentIds !== null && !Array.isArray(parsed.stagedAttachmentIds)) {
+    throw new Error("invalid Slack inbox attachment checkpoint");
+  }
+  if (parsed.defer !== null && typeof parsed.defer !== "object") {
+    throw new Error("invalid Slack inbox defer metadata");
+  }
+  return {
+    schema: 1,
+    envelope: parsed.envelope,
+    identity: parsed.identity,
+    stagedAttachmentIds: parsed.stagedAttachmentIds === null
+      ? null
+      : parsed.stagedAttachmentIds.filter((id): id is string => typeof id === "string"),
+    defer: parsed.defer ?? null,
+  };
+}
+
+async function claimSlackInboxEvents(limit = CLAIM_LIMIT): Promise<ClaimedSlackInboxEvent[]> {
+  const claimToken = crypto.randomUUID();
+  const rows = (await db.execute(sql`
+    with due as (
+      select id from commands
+      where kind = ${SLACK_INBOX_EVENT}
+        and attempt_count < ${MAX_ATTEMPTS}
+        and (
+          state = 'queued' and (
+            payload::jsonb -> 'defer' = 'null'::jsonb
+            or (payload::jsonb #>> '{defer,nextAttemptAt}')::timestamptz <= now()
+          )
+          or (state = 'dispatched' and updated_at < now() - (${STALE_CLAIM_SECONDS} * interval '1 second'))
+        )
+      order by created_at asc, id asc
+      limit ${limit}
+      for update skip locked
+    )
+    update commands c
+    set state = 'dispatched', attempt_count = attempt_count + 1,
+        updated_at = now(), error = ${claimToken}
+    from due where c.id = due.id
+    returning c.id, c.payload, c.attempt_count`)) as unknown as Array<Record<string, unknown>>;
+  return rows.map((row) => ({
+    id: row.id as string,
+    payload: row.payload as string,
+    attemptCount: Number(row.attempt_count),
+    claimToken,
+  }));
+}
+
+async function failExhaustedStaleClaims(): Promise<number> {
+  const rows = await db.execute(sql`
+    update commands
+    set state = 'failed', error = 'retry_exhausted_after_restart', updated_at = now()
+    where kind = ${SLACK_INBOX_EVENT}
+      and state = 'dispatched'
+      and attempt_count >= ${MAX_ATTEMPTS}
+      and updated_at < now() - (${STALE_CLAIM_SECONDS} * interval '1 second')
+    returning id`);
+  return rows.length;
+}
+
+interface ClaimHeartbeat {
+  stop(): Promise<boolean>;
+}
+
+function startClaimHeartbeat(row: ClaimedSlackInboxEvent): ClaimHeartbeat {
+  let stopped = false;
+  let lost = false;
+  let pending = Promise.resolve();
+  const beat = () => {
+    pending = pending.then(async () => {
+      if (stopped || lost) return;
+      const updated = await db.execute(sql`
+        update commands set updated_at = now()
+        where id = ${row.id} and state = 'dispatched' and error = ${row.claimToken}
+        returning id`);
+      if (updated.length === 0) lost = true;
+    }).catch((error) => {
+      console.error("[slack] inbox heartbeat failed:", (error as Error).message);
+    });
+  };
+  const timer = setInterval(beat, CLAIM_HEARTBEAT_MS);
+  timer.unref?.();
+  return {
+    async stop() {
+      if (!stopped) {
+        stopped = true;
+        clearInterval(timer);
+      }
+      await pending;
+      return lost;
+    },
+  };
+}
+
+async function updateClaim(
+  row: ClaimedSlackInboxEvent,
+  values: Partial<typeof commands.$inferInsert>,
+): Promise<void> {
+  const updated = await db
+    .update(commands)
+    .set({ ...values, updatedAt: new Date() })
+    .where(and(
+      eq(commands.id, row.id),
+      eq(commands.state, "dispatched"),
+      eq(commands.error, row.claimToken),
+    ))
+    .returning({ id: commands.id });
+  if (updated.length === 0) throw new StaleSlackInboxClaimError();
+}
+
+async function checkpointStagedAttachmentIds(
+  row: ClaimedSlackInboxEvent,
+  current: SlackInboxPayload,
+  ids: readonly string[],
+): Promise<void> {
+  const payload = serializePayload({ ...current, stagedAttachmentIds: [...ids] });
+  await updateClaim(row, { payload });
+}
+
+async function completeClaim(row: ClaimedSlackInboxEvent): Promise<void> {
+  await updateClaim(row, { state: "completed", error: null });
+}
+
+async function failClaim(row: ClaimedSlackInboxEvent, error: string): Promise<void> {
+  await updateClaim(row, { state: "failed", error: error.slice(0, 500) });
+}
+
+async function requeueClaim(
+  row: ClaimedSlackInboxEvent,
+  error: string,
+): Promise<void> {
+  await updateClaim(row, { state: "queued", error: error.slice(0, 500) });
+}
+
+async function deferClaim(
+  row: ClaimedSlackInboxEvent,
+  payload: SlackInboxPayload,
+  reason: string,
+  policy: {
+    readonly baseMs: number;
+    readonly maxMs: number;
+    readonly maxCount: number;
+    readonly expireMs: number;
+  } = {
+    baseMs: DEFER_BASE_MS,
+    maxMs: DEFER_MAX_MS,
+    maxCount: DEFER_MAX_COUNT,
+    expireMs: DEFER_EXPIRE_MS,
+  },
+): Promise<"queued" | "expired"> {
+  const now = Date.now();
+  const previous = payload.defer?.reason === reason ? payload.defer : null;
+  const firstDeferredAt = previous?.firstDeferredAt ?? new Date(now).toISOString();
+  const firstMs = Date.parse(firstDeferredAt);
+  const count = (previous?.count ?? 0) + 1;
+  if (
+    count >= policy.maxCount ||
+    !Number.isFinite(firstMs) ||
+    now - firstMs >= policy.expireMs
+  ) {
+    return "expired";
+  }
+  const delayMs = Math.min(policy.maxMs, policy.baseMs * 2 ** Math.max(0, count - 1));
+  const nextPayload = serializePayload({
+    ...payload,
+    defer: {
+      reason,
+      count,
+      firstDeferredAt,
+      nextAttemptAt: new Date(now + delayMs).toISOString(),
+    },
+  });
+  const updated = await db.execute(sql`
+    update commands
+    set state = 'queued',
+        attempt_count = greatest(attempt_count - 1, 0),
+        payload = ${nextPayload},
+        error = ${reason.slice(0, 500)},
+        updated_at = now()
+    where id = ${row.id} and state = 'dispatched' and error = ${row.claimToken}
+    returning id`);
+  if (updated.length === 0) throw new StaleSlackInboxClaimError();
+  return "queued";
+}
+
+async function completeExpiredRootProbation(row: ClaimedSlackInboxEvent): Promise<void> {
+  await updateClaim(row, {
+    state: "completed",
+    error: "permanent_noop:awaiting_root_commit_expired",
+  });
+}
+
+export type SlackInboxIdentityVerdict =
+  | { readonly status: "verified"; readonly orgId: string; readonly actorId: string | null }
+  | { readonly status: "ignored" }
+  | { readonly status: "rebound"; readonly error: string };
+
+/** Verify current bindings still equal the immutable ingress-time identity. */
+export async function verifySlackInboxIdentity(
+  payload: SlackInboxPayload,
+): Promise<SlackInboxIdentityVerdict> {
+  const identity = payload.identity;
+  if (!identity.teamId || !identity.orgId) return { status: "ignored" };
+  const workspace = await findSlackWorkspace(identity.teamId);
+  if (workspace?.orgId !== identity.orgId) {
+    return { status: "rebound", error: "slack_workspace_binding_changed" };
+  }
+  if (!identity.slackUserId) {
+    return identity.actorId === null
+      ? { status: "verified", orgId: identity.orgId, actorId: null }
+      : { status: "rebound", error: "slack_sender_binding_changed" };
+  }
+  const sender = await findSlackUser(identity.teamId, identity.slackUserId);
+  const currentActor = sender?.orgId === identity.orgId ? sender.userId : null;
+  if (currentActor !== identity.actorId) {
+    return { status: "rebound", error: "slack_sender_binding_changed" };
+  }
+  return { status: "verified", orgId: identity.orgId, actorId: identity.actorId };
+}
+
+export interface SlackInboxPassResult {
+  readonly claimed: number;
+  readonly completed: number;
+  readonly requeued: number;
+  readonly failed: number;
+}
+
+export async function processSlackInbox(handler: SlackInboxHandler): Promise<SlackInboxPassResult> {
+  const exhausted = await failExhaustedStaleClaims();
+  const rows = await claimSlackInboxEvents();
+  const heartbeats = new Map(rows.map((row) => [row.id, startClaimHeartbeat(row)]));
+  let completed = 0;
+  let requeued = 0;
+  let failed = exhausted;
+  for (const row of rows) {
+    const heartbeat = heartbeats.get(row.id)!;
+    try {
+      let payload = parsePayload(row.payload);
+      const outcome = await handler({
+        payload,
+        checkpointStagedAttachmentIds: async (ids) => {
+          await checkpointStagedAttachmentIds(row, payload, ids);
+          payload = { ...payload, stagedAttachmentIds: [...ids] };
+        },
+      });
+      if (await heartbeat.stop()) throw new StaleSlackInboxClaimError();
+      if (outcome.status === "completed") {
+        await completeClaim(row);
+        completed++;
+      } else if (outcome.status === "retryable_unavailable") {
+        const deferred = await deferClaim(row, payload, outcome.error);
+        if (deferred === "expired") {
+          await failClaim(row, `deferred_expired:${outcome.error}`);
+          failed++;
+        } else requeued++;
+      } else if (outcome.status === "waiting_for_root") {
+        const deferred = await deferClaim(row, payload, "awaiting_root_commit", {
+          baseMs: ROOT_PROBATION_BASE_MS,
+          maxMs: ROOT_PROBATION_MAX_MS,
+          maxCount: ROOT_PROBATION_MAX_COUNT,
+          expireMs: ROOT_PROBATION_EXPIRE_MS,
+        });
+        if (deferred === "expired") {
+          await completeExpiredRootProbation(row);
+          completed++;
+        } else requeued++;
+      } else {
+        await failClaim(row, outcome.error);
+        failed++;
+      }
+    } catch (error) {
+      await heartbeat.stop();
+      if (error instanceof StaleSlackInboxClaimError) continue;
+      if (row.attemptCount >= MAX_ATTEMPTS) {
+        await failClaim(row, (error as Error).message);
+        failed++;
+      } else {
+        await requeueClaim(row, (error as Error).message);
+        requeued++;
+      }
+    }
+  }
+  return { claimed: rows.length, completed, requeued, failed };
+}
+
+export interface SlackInboxRetentionResult {
+  readonly redacted: number;
+  readonly deleted: number;
+}
+
+/** Redact terminal payloads after one day and delete them after seven days. */
+export async function maintainSlackInboxRetention(): Promise<SlackInboxRetentionResult> {
+  const redacted = await db.execute(sql`
+    with due as (
+      select id from commands
+      where kind = ${SLACK_INBOX_EVENT}
+        and state in ('completed', 'failed')
+        and created_at < now() - (${TERMINAL_REDACT_AFTER_SECONDS} * interval '1 second')
+        and payload not like '%"redacted"%'
+      order by created_at asc
+      limit ${RETENTION_BATCH}
+      for update skip locked
+    )
+    update commands c
+    set payload = json_build_object(
+          'schema', 1,
+          'redacted', true,
+          'terminalState', c.state,
+          'orgId', c.org_id,
+          'actorId', c.actor_id
+        )::text,
+        updated_at = now()
+    from due where c.id = due.id
+    returning c.id`);
+  const deleted = await db.execute(sql`
+    with due as (
+      select id from commands
+      where kind = ${SLACK_INBOX_EVENT}
+        and state in ('completed', 'failed')
+        and created_at < now() - (${TERMINAL_DELETE_AFTER_SECONDS} * interval '1 second')
+      order by created_at asc
+      limit ${RETENTION_BATCH}
+      for update skip locked
+    )
+    delete from commands c using due where c.id = due.id
+    returning c.id`);
+  return { redacted: redacted.length, deleted: deleted.length };
+}
+
+let handler: SlackInboxHandler | null = null;
+let pumpTimer: ReturnType<typeof setInterval> | null = null;
+let pumpInFlight = false;
+let rerunRequested = false;
+let lastRetentionSweepAt = 0;
+
+async function pump(): Promise<void> {
+  if (!handler) return;
+  if (pumpInFlight) {
+    rerunRequested = true;
+    return;
+  }
+  pumpInFlight = true;
+  try {
+    await processSlackInbox(handler);
+    if (Date.now() - lastRetentionSweepAt >= RETENTION_INTERVAL_MS) {
+      await maintainSlackInboxRetention();
+      lastRetentionSweepAt = Date.now();
+    }
+  } catch (error) {
+    console.error("[slack] inbox pump failed:", (error as Error).message);
+  } finally {
+    pumpInFlight = false;
+    if (rerunRequested) {
+      rerunRequested = false;
+      queueMicrotask(() => void pump());
+    }
+  }
+}
+
+/** Start boot recovery plus low-latency interval processing. */
+export function startSlackInboxPump(nextHandler: SlackInboxHandler): void {
+  handler = nextHandler;
+  void pump();
+  if (pumpTimer) return;
+  pumpTimer = setInterval(() => void pump(), PUMP_INTERVAL_MS);
+  pumpTimer.unref?.();
+}
+
+/** Wake the pump after a committed inbox insert. */
+export function kickSlackInbox(): void {
+  void pump();
+}
+
+export function stopSlackInboxPumpForTest(): void {
+  handler = null;
+  rerunRequested = false;
+  if (pumpTimer) clearInterval(pumpTimer);
+  pumpTimer = null;
+  pumpInFlight = false;
+}

--- a/backend/src/slack/inbox.ts
+++ b/backend/src/slack/inbox.ts
@@ -648,31 +648,36 @@ export async function maintainSlackInboxRetention(): Promise<SlackInboxRetention
 let handler: SlackInboxHandler | null = null;
 let pumpTimer: ReturnType<typeof setInterval> | null = null;
 let pumpInFlight = false;
+let pumpCompletion: Promise<void> | null = null;
 let rerunRequested = false;
 let lastRetentionSweepAt = 0;
 
-async function pump(): Promise<void> {
-  if (!handler) return;
+function pump(): Promise<void> {
+  if (!handler) return Promise.resolve();
   if (pumpInFlight) {
     rerunRequested = true;
-    return;
+    return pumpCompletion ?? Promise.resolve();
   }
   pumpInFlight = true;
-  try {
-    await processSlackInbox(handler);
-    if (Date.now() - lastRetentionSweepAt >= RETENTION_INTERVAL_MS) {
-      await maintainSlackInboxRetention();
-      lastRetentionSweepAt = Date.now();
+  pumpCompletion = (async () => {
+    try {
+      await processSlackInbox(handler);
+      if (Date.now() - lastRetentionSweepAt >= RETENTION_INTERVAL_MS) {
+        await maintainSlackInboxRetention();
+        lastRetentionSweepAt = Date.now();
+      }
+    } catch (error) {
+      console.error("[slack] inbox pump failed:", (error as Error).message);
+    } finally {
+      pumpInFlight = false;
+      pumpCompletion = null;
+      if (rerunRequested) {
+        rerunRequested = false;
+        queueMicrotask(() => void pump());
+      }
     }
-  } catch (error) {
-    console.error("[slack] inbox pump failed:", (error as Error).message);
-  } finally {
-    pumpInFlight = false;
-    if (rerunRequested) {
-      rerunRequested = false;
-      queueMicrotask(() => void pump());
-    }
-  }
+  })();
+  return pumpCompletion;
 }
 
 /** Start boot recovery plus low-latency interval processing. */
@@ -689,10 +694,10 @@ export function kickSlackInbox(): void {
   void pump();
 }
 
-export function stopSlackInboxPumpForTest(): void {
+export async function stopSlackInboxPumpForTest(): Promise<void> {
   handler = null;
   rerunRequested = false;
   if (pumpTimer) clearInterval(pumpTimer);
   pumpTimer = null;
-  pumpInFlight = false;
+  await pumpCompletion;
 }

--- a/backend/src/slack/index.ts
+++ b/backend/src/slack/index.ts
@@ -18,6 +18,8 @@
 import { slackConfig } from "../env";
 import { startSlackOutboxRelay } from "./outbox";
 import { startSlackSocketMode } from "./socket-mode";
+import { handleSlackEvent, slackEventIsEarlyNoop } from "./events";
+import { startSlackInboxPump, verifySlackInboxIdentity } from "./inbox";
 
 export { slackRoutes } from "./routes";
 export { slackEnabled } from "../env";
@@ -27,11 +29,33 @@ export { syncSlackWorkspaceBindings } from "./workspaces";
 
 /** Start the durable outbox delivery relay (boot recovery + interval) and,
  *  when SLACK_APP_TOKEN is set, the Socket Mode ingress (WebSocket lane - no
- *  public URL required; shares the HTTP path's handler + deduper). Called
+ *  public URL required; both transports persist into the same inbox). Called
  *  from src/index.ts only when Slack is configured. No-op if unconfigured. */
 export function startSlackOutbox(): void {
   const cfg = slackConfig();
   if (!cfg) return;
   startSlackOutboxRelay(cfg);
+  startSlackInboxPump(async ({ payload, checkpointStagedAttachmentIds }) => {
+    if (slackEventIsEarlyNoop(payload.envelope)) return { status: "completed" };
+    const identity = await verifySlackInboxIdentity(payload);
+    if (identity.status === "ignored") return { status: "completed" };
+    if (identity.status === "rebound") {
+      return { status: "permanent", error: identity.error };
+    }
+    const outcome = await handleSlackEvent(payload.envelope, {
+      identity,
+      stagedAttachmentIds: payload.stagedAttachmentIds,
+      checkpointStagedAttachmentIds,
+    });
+    if (
+      outcome.status === "accepted" ||
+      outcome.status === "replayed" ||
+      outcome.status === "permanent_noop"
+    ) {
+      return { status: "completed" };
+    }
+    if (outcome.status === "waiting_for_root") return { status: "waiting_for_root" };
+    return { status: "retryable_unavailable", error: outcome.reason };
+  });
   startSlackSocketMode();
 }

--- a/backend/src/slack/routes.ts
+++ b/backend/src/slack/routes.ts
@@ -4,14 +4,16 @@
  *   1. read the RAW body (needed byte-for-byte for signature verification),
  *   2. verify the Slack request signature (401 on failure),
  *   3. answer the one-time `url_verification` challenge (synchronous),
- *   4. ACK `event_callback`s with a 200 IMMEDIATELY and process async.
+ *   4. persist `event_callback`s in the durable inbox,
+ *   5. ACK only after that commit succeeds.
  *
  * The route is also self-gated: with the adapter unconfigured it 404s, so it is
  * inert even if somehow mounted.
  */
 import { Hono } from "hono";
 import { slackConfig } from "../env";
-import { handleSlackEvent, type SlackEnvelope } from "./events";
+import { slackEventIsEarlyNoop, type SlackEnvelope } from "./events";
+import { classifySlackInboxEvent, persistSlackInboxEvent } from "./inbox";
 import { verifySlackSignature } from "./verify";
 
 export const slackRoutes = new Hono();
@@ -42,24 +44,24 @@ slackRoutes.post("/events", async (c) => {
   }
 
   if (body.type === "event_callback") {
-    // ACK-FIRST: the 200 goes back within milliseconds of signature
-    // verification - Slack's 3s ack budget must never wait on run acceptance
-    // (DB writes, attachment downloads). Processing continues asynchronously;
-    // failures are logged, never surfaced (a 5xx would make Slack retry-storm
-    // us). A RETRY delivery (x-slack-retry-num) is acked the same way and is
-    // never reprocessed into a second run: the dedupe lanes (in-memory
-    // channel:ts + the durable slack-event command key) collapse it. The header
-    // alone is NOT used to drop the event - a retry can also mean the first
-    // attempt never reached us, and then it is the only delivery we get.
+    if (slackEventIsEarlyNoop(body)) return c.body(null, 200);
+    // Slack gets a 200 only after the authenticated envelope and its resolved
+    // identity commit. A DB failure intentionally returns 503 so Slack retries;
+    // run acceptance, attachment downloads, and provider work remain async.
     const retryNum = c.req.header("x-slack-retry-num");
     if (retryNum) {
       console.log(
         `[slack] retry delivery (num ${retryNum}, reason ${c.req.header("x-slack-retry-reason") ?? "unknown"})`,
       );
     }
-    void handleSlackEvent(body).catch((err) => {
-      console.error("[slack] event handler error:", (err as Error).message);
-    });
+    try {
+      const decision = await classifySlackInboxEvent(body);
+      if (decision === "drop") return c.body(null, 200);
+      await persistSlackInboxEvent(body, decision);
+    } catch (error) {
+      console.error("[slack] inbox persistence failed:", (error as Error).message);
+      return c.json({ error: "slack_ingress_unavailable" }, 503);
+    }
   }
 
   return c.body(null, 200);

--- a/backend/src/slack/socket-mode.ts
+++ b/backend/src/slack/socket-mode.ts
@@ -2,8 +2,8 @@
  * Slack Socket Mode transport - an OUTBOUND WebSocket ingress for the same
  * event pipeline as the HTTP receiver (routes.ts). Config-gated on
  * SLACK_APP_TOKEN (xapp-...): when present, we call apps.connections.open,
- * connect to the returned wss URL, ack every envelope by envelope_id, and feed
- * `events_api` payloads into the SAME handleSlackEvent used by the HTTP path.
+ * connect to the returned wss URL, persist `events_api` payloads into the same
+ * durable inbox as HTTP, then ack by envelope_id only after the commit.
  * No public URL or signing verification is involved - Slack authenticates the
  * connection via the app-level token, and events arrive only on sockets we
  * opened.
@@ -14,7 +14,8 @@
  * load-balances events across ALL open Socket Mode connections for the app -
  * if another service also holds a socket for this app, each receives a subset.
  */
-import { handleSlackEvent, type SlackEnvelope } from "./events";
+import { slackEventIsEarlyNoop, type SlackEnvelope } from "./events";
+import { classifySlackInboxEvent, persistSlackInboxEvent } from "./inbox";
 
 const RECONNECT_DELAY_MS = 3_000;
 
@@ -57,36 +58,47 @@ function scheduleReconnect(token: string): void {
 }
 
 /**
- * Dispatch one decoded Socket Mode frame: ack by envelope_id, then route by
- * type. `events_api` payloads go to the SAME handleSlackEvent the HTTP route
- * uses, so a Socket-Mode-ingested event creates a run and attaches the live
- * status/reply watcher (watchSlackRun) identically to the HTTP path. Extracted
- * from ws.onmessage so it is unit-testable without a live WebSocket.
+ * Dispatch one decoded Socket Mode frame. Authenticated `events_api` payloads
+ * are acked only after durable inbox persistence. A persistence failure leaves
+ * the envelope unacked so Slack retries it on this or another socket.
  */
 export function dispatchSocketFrame(
   raw: string,
   ack: (envelopeId: string) => void,
   onDisconnect: () => void,
-): void {
+): Promise<void> {
   let env: SocketEnvelope;
   try {
     env = JSON.parse(raw) as SocketEnvelope;
   } catch {
-    return;
+    return Promise.resolve();
   }
-  // Ack FIRST (3s budget), then process - mirrors the HTTP path's fast-ack.
-  if (env.envelope_id) ack(env.envelope_id);
-  if (env.type === "hello") return;
+  if (env.type === "hello") {
+    if (env.envelope_id) ack(env.envelope_id);
+    return Promise.resolve();
+  }
   if (env.type === "disconnect") {
+    if (env.envelope_id) ack(env.envelope_id);
     // Slack asks us to refresh; closing the socket triggers the reconnect.
     onDisconnect();
-    return;
+    return Promise.resolve();
   }
   if (env.type === "events_api" && env.payload) {
-    void handleSlackEvent(env.payload).catch((err) =>
-      console.error("[slack:socket] event handling failed:", err),
-    );
+    if (slackEventIsEarlyNoop(env.payload)) {
+      if (env.envelope_id) ack(env.envelope_id);
+      return Promise.resolve();
+    }
+    return classifySlackInboxEvent(env.payload)
+      .then(async (decision) => {
+        if (decision !== "drop") await persistSlackInboxEvent(env.payload!, decision);
+        if (env.envelope_id) ack(env.envelope_id);
+      })
+      .catch((error) => {
+        console.error("[slack:socket] inbox persistence failed:", (error as Error).message);
+      });
   }
+  if (env.envelope_id) ack(env.envelope_id);
+  return Promise.resolve();
 }
 
 async function connect(token: string): Promise<void> {
@@ -98,8 +110,8 @@ async function connect(token: string): Promise<void> {
   socket = ws;
 
   ws.onopen = () => console.log("[slack:socket] connected (socket mode)");
-  ws.onmessage = (msg) =>
-    dispatchSocketFrame(
+  ws.onmessage = (msg) => {
+    void dispatchSocketFrame(
       String(msg.data),
       (id) => ws.send(JSON.stringify({ envelope_id: id })),
       () => {
@@ -110,6 +122,7 @@ async function connect(token: string): Promise<void> {
         }
       },
     );
+  };
   ws.onclose = () => {
     if (socket === ws) socket = null;
     scheduleReconnect(token);
@@ -131,8 +144,8 @@ function isTestEnv(): boolean {
 }
 
 /** Start the Socket Mode ingress. No-op unless SLACK_APP_TOKEN is set (the
- *  HTTP events route stays mounted either way - both lanes share the deduper
- *  in events.ts, so double delivery collapses to one run).
+ *  HTTP events route stays mounted either way - both lanes share the durable
+ *  inbox, so double delivery collapses before processing).
  *
  *  HARD no-op under test: a test-booted server carrying the real SLACK_APP_TOKEN
  *  would otherwise open a live WebSocket to the workspace and STEAL real events

--- a/backend/test/slack.test.ts
+++ b/backend/test/slack.test.ts
@@ -1122,7 +1122,7 @@ describe("slack native stream and Block Kit fallback", () => {
 
 describe("slack durable inbox", () => {
   test("persists one duplicate event while closed and drains it once after restart/open", async () => {
-    stopSlackInboxPumpForTest();
+    await stopSlackInboxPumpForTest();
     const operationId = `slack-deferred-test:${crypto.randomUUID()}`;
     const marker = uid("deferred");
     const channel = `C${uid("ch")}`;
@@ -1176,7 +1176,7 @@ describe("slack durable inbox", () => {
         const [row] = await db.select().from(commands).where(eq(commands.id, inboxKey));
         return row?.state === "queued" && row.attemptCount === 0 ? row : null;
       });
-      stopSlackInboxPumpForTest();
+      await stopSlackInboxPumpForTest();
       const [delayed] = await db.select().from(commands).where(eq(commands.id, inboxKey));
       const defer = (JSON.parse(delayed.payload!) as {
         defer: { reason: string; nextAttemptAt: string };
@@ -1232,7 +1232,7 @@ describe("slack durable inbox", () => {
   });
 
   test("fails closed when the persisted sender binding changes before replay", async () => {
-    stopSlackInboxPumpForTest();
+    await stopSlackInboxPumpForTest();
     const marker = uid("rebind");
     const envelope = eventCallback({
       type: "app_mention",
@@ -1264,7 +1264,7 @@ describe("slack durable inbox", () => {
   });
 
   test("a stale worker cannot complete a claim reclaimed by a new worker", async () => {
-    stopSlackInboxPumpForTest();
+    await stopSlackInboxPumpForTest();
     const envelope = eventCallback({
       type: "app_mention",
       channel: `C${uid("ch")}`,
@@ -1300,7 +1300,7 @@ describe("slack durable inbox", () => {
   });
 
   test("the eighth processing error permanently fails the inbox row", async () => {
-    stopSlackInboxPumpForTest();
+    await stopSlackInboxPumpForTest();
     const envelope = eventCallback({
       type: "app_mention",
       channel: `C${uid("ch")}`,
@@ -1319,7 +1319,7 @@ describe("slack durable inbox", () => {
   });
 
   test("retryable unavailability is delayed and resumes when due", async () => {
-    stopSlackInboxPumpForTest();
+    await stopSlackInboxPumpForTest();
     const envelope = eventCallback({
       type: "app_mention",
       channel: `C${uid("ch")}`,
@@ -1365,7 +1365,7 @@ describe("slack durable inbox", () => {
   });
 
   test("an unrelated reply probation expires once into a retention-eligible no-op", async () => {
-    stopSlackInboxPumpForTest();
+    await stopSlackInboxPumpForTest();
     const envelope = eventCallback({
       type: "message",
       channel: `C${uid("ch")}`,
@@ -1413,7 +1413,7 @@ describe("slack durable inbox", () => {
   });
 
   test("fails an exhausted stale dispatch left by a crashed process", async () => {
-    stopSlackInboxPumpForTest();
+    await stopSlackInboxPumpForTest();
     const envelope = eventCallback({
       type: "app_mention",
       channel: `C${uid("ch")}`,
@@ -1451,7 +1451,7 @@ describe("slack durable inbox", () => {
   });
 
   test("reply persists before the root INSERT commits, then attaches exactly once", async () => {
-    stopSlackInboxPumpForTest();
+    await stopSlackInboxPumpForTest();
     const marker = uid("root-commit-race");
     const channel = `C${uid("ch")}`;
     const rootTs = `${uid("root")}.1`;
@@ -1538,7 +1538,7 @@ describe("slack durable inbox", () => {
   });
 
   test("Slack root-thread lookup uses the existing commands thread-state index", async () => {
-    stopSlackInboxPumpForTest();
+    await stopSlackInboxPumpForTest();
     const prefix = `slack-plan-${crypto.randomUUID()}`;
     const targetThread = `${prefix}-target`;
     try {
@@ -1572,7 +1572,7 @@ describe("slack durable inbox", () => {
   });
 
   test("closed root then reply both drain after admission reopens", async () => {
-    stopSlackInboxPumpForTest();
+    await stopSlackInboxPumpForTest();
     const operationId = `slack-root-reply:${crypto.randomUUID()}`;
     const marker = uid("closed-thread");
     const channel = `C${uid("ch")}`;
@@ -1632,7 +1632,7 @@ describe("slack durable inbox", () => {
   });
 
   test("a reply processed before its pending root waits durably then attaches", async () => {
-    stopSlackInboxPumpForTest();
+    await stopSlackInboxPumpForTest();
     const marker = uid("reverse-thread");
     const channel = `C${uid("ch")}`;
     const rootTs = `${uid("root")}.1`;
@@ -1675,7 +1675,7 @@ describe("slack durable inbox", () => {
   });
 
   test("a healthy claim heartbeat prevents reclaim after more than 30 seconds", async () => {
-    stopSlackInboxPumpForTest();
+    await stopSlackInboxPumpForTest();
     const envelope = eventCallback({
       type: "app_mention",
       channel: `C${uid("ch")}`,
@@ -1714,7 +1714,7 @@ describe("slack durable inbox", () => {
   }, 45_000);
 
   test("canonical storage drops unknown fields and terminal retention redacts then deletes", async () => {
-    stopSlackInboxPumpForTest();
+    await stopSlackInboxPumpForTest();
     const secret = `provider-secret-${uid("secret")}`;
     const envelope = {
       ...eventCallback({
@@ -2341,7 +2341,7 @@ describe("slack inbound attachments", () => {
   });
 
   test("a close after file staging checkpoints IDs and replay does not redownload", async () => {
-    stopSlackInboxPumpForTest();
+    await stopSlackInboxPumpForTest();
     const operationId = `slack-stage-reclose:${crypto.randomUUID()}`;
     const marker = uid("reclose");
     const fileName = `${marker}.txt`;

--- a/backend/test/slack.test.ts
+++ b/backend/test/slack.test.ts
@@ -18,9 +18,9 @@ import {
   test,
 } from "bun:test";
 import { createHmac } from "node:crypto";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { db } from "../src/db/client";
-import { artifacts, runs, slackOutbox, slackRunResponses, slackThreads, userUploads } from "../src/db/schema";
+import { artifacts, commands, runs, slackOutbox, slackRunResponses, slackThreads, userUploads } from "../src/db/schema";
 import { artifactStorage } from "../src/artifacts/storage";
 import { finalizeRun } from "../src/runs/finalize";
 import { createRun } from "../src/runs/repo";
@@ -42,8 +42,24 @@ import { markdownChunksFor, openingStreamChunks, runningTaskChunk } from "../src
 import { turnStream } from "../src/runs/turn-stream";
 import { DEV_ORG_ID, DEV_USER_ID } from "../src/seed";
 import { setSlackClientForTest } from "../src/slack";
-import { resetSlackDeduperForTest } from "../src/slack/events";
+import { handleSlackEvent, resetSlackDeduperForTest, type SlackEnvelope } from "../src/slack/events";
 import { setInboundFileDownloaderForTest } from "../src/slack/inbound-files";
+import {
+  persistSlackInboxEvent,
+  processSlackInbox,
+  maintainSlackInboxRetention,
+  setSlackInboxBeforePersistInsertForTest,
+  setSlackInboxPersisterForTest,
+  slackInboxKey,
+  slackInboxThreadId,
+  SLACK_INBOX_EVENT,
+  startSlackInboxPump,
+  stopSlackInboxPumpForTest,
+  verifySlackInboxIdentity,
+  type SlackInboxClaim,
+  type SlackInboxOutcome,
+  type SlackInboxPayload,
+} from "../src/slack/inbox";
 import { dispatchSocketFrame } from "../src/slack/socket-mode";
 import { composeSlackReplyText } from "../src/slack/reply";
 import {
@@ -54,6 +70,7 @@ import {
   upsertSlackWorkspace,
 } from "../src/slack/workspaces";
 import { fetchApi, json, uid, waitFor } from "./helpers";
+import { setRunAdmission } from "../src/commands";
 
 // This DB-backed integration suite shares the CI Postgres service with the
 // full backend matrix. Keep its bounded async waits above Bun's 5s unit-test
@@ -283,6 +300,30 @@ async function deleteSlackDeliveryRows(runId: string, teamId = TEAM): Promise<vo
   `);
 }
 
+async function replaySlackInboxClaim(claim: SlackInboxClaim): Promise<SlackInboxOutcome> {
+  const identity = await verifySlackInboxIdentity(claim.payload);
+  if (identity.status === "ignored") return { status: "completed" };
+  if (identity.status === "rebound") return { status: "permanent", error: identity.error };
+  const outcome = await handleSlackEvent(claim.payload.envelope, {
+    identity,
+    stagedAttachmentIds: claim.payload.stagedAttachmentIds,
+    checkpointStagedAttachmentIds: claim.checkpointStagedAttachmentIds,
+  });
+  if (
+    outcome.status === "accepted" ||
+    outcome.status === "replayed" ||
+    outcome.status === "permanent_noop"
+  ) {
+    return { status: "completed" };
+  }
+  if (outcome.status === "waiting_for_root") return { status: "waiting_for_root" };
+  return { status: "retryable_unavailable", error: outcome.reason };
+}
+
+function restartSlackInboxPumpForTest(): void {
+  startSlackInboxPump(replaySlackInboxClaim);
+}
+
 describe("slack signature verification", () => {
   test("url_verification handshake echoes the challenge (signed)", async () => {
     const res = await postSlack({ type: "url_verification", challenge: "c-123" });
@@ -313,6 +354,26 @@ describe("slack signature verification", () => {
       headers: { "content-type": "application/json" },
     });
     expect(res.status).toBe(401);
+  });
+
+  test("a verified HTTP event is not ACKed when inbox persistence fails", async () => {
+    const marker = uid("persist-fail");
+    setSlackInboxPersisterForTest(async () => {
+      throw new Error("synthetic inbox outage");
+    });
+    try {
+      const res = await postSlack(eventCallback({
+        type: "app_mention",
+        channel: `C${uid("ch")}`,
+        user: "U-HUMAN",
+        text: `<@${BOT}> ${marker}`,
+        ts: `${uid("ts")}.1`,
+      }));
+      expect(res.status).toBe(503);
+      expect(await findRunByPrompt(marker)).toBeNull();
+    } finally {
+      setSlackInboxPersisterForTest(null);
+    }
   });
 });
 
@@ -689,20 +750,21 @@ describe("slack event → run", () => {
 
   test("a non-mention channel message in an unknown thread is ignored", async () => {
     const marker = uid("ignore");
-    const res = await postSlack(
-      eventCallback({
-        type: "message",
-        channel: `C${uid("ch")}`,
-        channel_type: "channel",
-        user: "U-HUMAN",
-        text: `noise ${marker}`,
-        ts: `${uid("ts")}.1`,
-      }),
-    );
+    const envelope = eventCallback({
+      type: "message",
+      channel: `C${uid("ch")}`,
+      channel_type: "channel",
+      user: "U-HUMAN",
+      text: `noise ${marker}`,
+      ts: `${uid("ts")}.1`,
+    }) as SlackEnvelope;
+    const res = await postSlack(envelope);
     expect(res.status).toBe(200); // acknowledged...
     // ...but no run created (give any async work a beat to NOT happen).
     await new Promise((r) => setTimeout(r, 150));
     expect(await findRunByPrompt(`noise ${marker}`)).toBeNull();
+    const [inbox] = await db.select().from(commands).where(eq(commands.id, slackInboxKey(envelope)));
+    expect(inbox).toBeUndefined(); // pure envelope gate runs before persistence
   });
 
   test("the bot's own message is ignored (loop guard)", async () => {
@@ -1058,10 +1120,656 @@ describe("slack native stream and Block Kit fallback", () => {
   });
 });
 
+describe("slack durable inbox", () => {
+  test("persists one duplicate event while closed and drains it once after restart/open", async () => {
+    stopSlackInboxPumpForTest();
+    const operationId = `slack-deferred-test:${crypto.randomUUID()}`;
+    const marker = uid("deferred");
+    const channel = `C${uid("ch")}`;
+    const ts = `${uid("ts")}.1`;
+    const envelope = eventCallback({
+      type: "app_mention",
+      channel,
+      user: "U-HUMAN",
+      text: `<@${BOT}> queued ${marker}`,
+      ts,
+    }) as SlackEnvelope;
+    const inboxKey = slackInboxKey(envelope);
+
+    await setRunAdmission({
+      open: false,
+      operationId,
+      actor: "test",
+      reason: "Slack deployment deferral test",
+    });
+    try {
+      expect((await postSlack(envelope)).status).toBe(200);
+      resetSlackDeduperForTest();
+      expect((await postSlack(envelope)).status).toBe(200);
+
+      const inbox = await waitFor(async () => {
+        const rows = await db
+          .select()
+          .from(commands)
+          .where(eq(commands.id, inboxKey));
+        return rows.length > 0 ? rows : null;
+      });
+      expect(inbox).toHaveLength(1);
+      expect(inbox[0]!.kind).toBe(SLACK_INBOX_EVENT);
+      expect(inbox[0]!.state).toBe("queued");
+      expect(inbox[0]!.orgId).toBe(DEV_ORG_ID);
+      expect(inbox[0]!.actorId).toBe(DEV_USER_ID);
+      expect(await findRunByPrompt(`queued ${marker}`)).toBeNull();
+
+      restartSlackInboxPumpForTest();
+      await waitFor(async () => {
+        const rows = await db
+          .select({ payload: slackOutbox.payload })
+          .from(slackOutbox)
+          .where(eq(
+            slackOutbox.idempotencyKey,
+            `slack-admission-queued:${TEAM}:${channel}:${ts}`,
+          ));
+        return rows[0] ?? null;
+      });
+      await waitFor(async () => {
+        const [row] = await db.select().from(commands).where(eq(commands.id, inboxKey));
+        return row?.state === "queued" && row.attemptCount === 0 ? row : null;
+      });
+      stopSlackInboxPumpForTest();
+      const [delayed] = await db.select().from(commands).where(eq(commands.id, inboxKey));
+      const defer = (JSON.parse(delayed.payload!) as {
+        defer: { reason: string; nextAttemptAt: string };
+      }).defer;
+      expect(defer.reason).toBe("run_admission_closed");
+      expect(Date.parse(defer.nextAttemptAt)).toBeGreaterThan(Date.now());
+      expect(await processSlackInbox(replaySlackInboxClaim)).toMatchObject({ claimed: 0 });
+      expect(await findRunByPrompt(`queued ${marker}`)).toBeNull();
+
+      // Simulate the deployment restart: the inbox row remains authoritative.
+      await setRunAdmission({
+        open: true,
+        operationId,
+        actor: "test",
+        reason: "deployment complete",
+      });
+      restartSlackInboxPumpForTest();
+      await waitFor(async () => findRunByPrompt(`queued ${marker}`));
+
+      resetSlackDeduperForTest();
+      expect((await postSlack(envelope)).status).toBe(200);
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      const { body } = await json<{ runs: any[] }>("/api/runs?all=1");
+      expect(body.runs.filter((run) => run.prompt === `queued ${marker}`)).toHaveLength(1);
+      const [completed] = await db
+        .select({ state: commands.state, attemptCount: commands.attemptCount })
+        .from(commands)
+        .where(eq(commands.id, inboxKey));
+      expect(completed).toEqual({ state: "completed", attemptCount: 1 });
+      const queuedNotices = await db
+        .select({ payload: slackOutbox.payload })
+        .from(slackOutbox)
+        .where(eq(
+          slackOutbox.idempotencyKey,
+          `slack-admission-queued:${TEAM}:${channel}:${ts}`,
+        ));
+      expect(queuedNotices).toHaveLength(1);
+      expect(queuedNotices[0]!.payload).toContain("start automatically");
+      expect(
+        rec.messages.some(
+          (message) => message.channel === channel && message.text.includes("Retry this message"),
+        ),
+      ).toBe(false);
+    } finally {
+      await setRunAdmission({
+        open: true,
+        operationId,
+        actor: "test",
+        reason: "test cleanup",
+      });
+      restartSlackInboxPumpForTest();
+    }
+  });
+
+  test("fails closed when the persisted sender binding changes before replay", async () => {
+    stopSlackInboxPumpForTest();
+    const marker = uid("rebind");
+    const envelope = eventCallback({
+      type: "app_mention",
+      channel: `C${uid("ch")}`,
+      user: "U-HUMAN",
+      text: `<@${BOT}> rebind ${marker}`,
+      ts: `${uid("ts")}.1`,
+    }) as SlackEnvelope;
+    const inboxKey = slackInboxKey(envelope);
+    try {
+      expect((await postSlack(envelope)).status).toBe(200);
+      await db.execute(sql`delete from slack_users where team_id = ${TEAM} and slack_user_id = 'U-HUMAN'`);
+      restartSlackInboxPumpForTest();
+      const failed = await waitFor(async () => {
+        const [row] = await db.select().from(commands).where(eq(commands.id, inboxKey));
+        return row?.state === "failed" ? row : null;
+      });
+      expect(failed.error).toBe("slack_sender_binding_changed");
+      expect(await findRunByPrompt(`rebind ${marker}`)).toBeNull();
+    } finally {
+      await upsertSlackUser({
+        teamId: TEAM,
+        slackUserId: "U-HUMAN",
+        orgId: DEV_ORG_ID,
+        userId: DEV_USER_ID,
+      });
+      restartSlackInboxPumpForTest();
+    }
+  });
+
+  test("a stale worker cannot complete a claim reclaimed by a new worker", async () => {
+    stopSlackInboxPumpForTest();
+    const envelope = eventCallback({
+      type: "app_mention",
+      channel: `C${uid("ch")}`,
+      user: "U-HUMAN",
+      text: `<@${BOT}> fence ${uid("fence")}`,
+      ts: `${uid("ts")}.1`,
+    }) as SlackEnvelope;
+    const inboxKey = slackInboxKey(envelope);
+    await persistSlackInboxEvent(envelope);
+    let entered!: () => void;
+    const claimed = new Promise<void>((resolve) => { entered = resolve; });
+    let release!: () => void;
+    const blocked = new Promise<void>((resolve) => { release = resolve; });
+    const staleWorker = processSlackInbox(async () => {
+      entered();
+      await blocked;
+      return { status: "completed" };
+    });
+    await claimed;
+    await db
+      .update(commands)
+      .set({ updatedAt: new Date(Date.now() - 31_000) })
+      .where(eq(commands.id, inboxKey));
+    expect(await processSlackInbox(async () => ({ status: "completed" }))).toMatchObject({
+      claimed: 1,
+      completed: 1,
+    });
+    release();
+    expect(await staleWorker).toMatchObject({ claimed: 1, completed: 0 });
+    const [row] = await db.select().from(commands).where(eq(commands.id, inboxKey));
+    expect(row.state).toBe("completed");
+    restartSlackInboxPumpForTest();
+  });
+
+  test("the eighth processing error permanently fails the inbox row", async () => {
+    stopSlackInboxPumpForTest();
+    const envelope = eventCallback({
+      type: "app_mention",
+      channel: `C${uid("ch")}`,
+      user: "U-HUMAN",
+      text: `<@${BOT}> retry cap ${uid("cap")}`,
+      ts: `${uid("ts")}.1`,
+    }) as SlackEnvelope;
+    const inboxKey = slackInboxKey(envelope);
+    await persistSlackInboxEvent(envelope);
+    for (let attempt = 1; attempt <= 8; attempt++) {
+      await processSlackInbox(async () => { throw new Error(`failure ${attempt}`); });
+    }
+    const [row] = await db.select().from(commands).where(eq(commands.id, inboxKey));
+    expect(row).toMatchObject({ state: "failed", attemptCount: 8, error: "failure 8" });
+    restartSlackInboxPumpForTest();
+  });
+
+  test("retryable unavailability is delayed and resumes when due", async () => {
+    stopSlackInboxPumpForTest();
+    const envelope = eventCallback({
+      type: "app_mention",
+      channel: `C${uid("ch")}`,
+      user: "U-HUMAN",
+      text: `<@${BOT}> unavailable ${uid("unavailable")}`,
+      ts: `${uid("ts")}.1`,
+    }) as SlackEnvelope;
+    const inboxKey = slackInboxKey(envelope);
+    try {
+      await persistSlackInboxEvent(envelope);
+      await processSlackInbox(async (claim) =>
+        slackInboxKey(claim.payload.envelope) === inboxKey
+          ? { status: "retryable_unavailable", error: "provider_unavailable" }
+          : replaySlackInboxClaim(claim));
+      let [row] = await db.select().from(commands).where(eq(commands.id, inboxKey));
+      const deferred = (JSON.parse(row.payload!) as {
+        defer: { count: number; reason: string; nextAttemptAt: string };
+      }).defer;
+      expect(deferred).toMatchObject({ count: 1, reason: "provider_unavailable" });
+      expect(Date.parse(deferred.nextAttemptAt)).toBeGreaterThan(Date.now());
+
+      await processSlackInbox(async () => ({ status: "completed" }));
+      [row] = await db.select().from(commands).where(eq(commands.id, inboxKey));
+      expect(row.state).toBe("queued");
+      expect(row.attemptCount).toBe(0);
+
+      const payload = JSON.parse(row.payload!) as SlackInboxPayload;
+      await db.update(commands).set({
+        payload: JSON.stringify({
+          ...payload,
+          defer: { ...payload.defer!, nextAttemptAt: new Date(Date.now() - 1_000).toISOString() },
+        }),
+      }).where(eq(commands.id, inboxKey));
+      await processSlackInbox(async (claim) =>
+        slackInboxKey(claim.payload.envelope) === inboxKey
+          ? { status: "completed" }
+          : replaySlackInboxClaim(claim));
+      [row] = await db.select().from(commands).where(eq(commands.id, inboxKey));
+      expect(row.state).toBe("completed");
+    } finally {
+      restartSlackInboxPumpForTest();
+    }
+  });
+
+  test("an unrelated reply probation expires once into a retention-eligible no-op", async () => {
+    stopSlackInboxPumpForTest();
+    const envelope = eventCallback({
+      type: "message",
+      channel: `C${uid("ch")}`,
+      channel_type: "channel",
+      user: "U-HUMAN",
+      text: `unrelated ${uid("expire")}`,
+      ts: `${uid("ts")}.1`,
+      thread_ts: `${uid("unrelated-root")}.0`,
+    }) as SlackEnvelope;
+    const inboxKey = slackInboxKey(envelope);
+    try {
+      expect((await postSlack(envelope)).status).toBe(200);
+      const [queued] = await db.select().from(commands).where(eq(commands.id, inboxKey));
+      const payload = JSON.parse(queued.payload!) as SlackInboxPayload;
+      expect(payload.defer).toMatchObject({ reason: "awaiting_root_commit", count: 0 });
+      expect(await processSlackInbox(replaySlackInboxClaim)).toMatchObject({ claimed: 0 });
+
+      await db.update(commands).set({
+        payload: JSON.stringify({
+          ...payload,
+          defer: {
+            ...payload.defer!,
+            count: 11,
+            firstDeferredAt: new Date(Date.now() - 3 * 60 * 1000).toISOString(),
+            nextAttemptAt: new Date(Date.now() - 1_000).toISOString(),
+          },
+        }),
+      }).where(eq(commands.id, inboxKey));
+      expect(await processSlackInbox(replaySlackInboxClaim)).toMatchObject({
+        claimed: 1,
+        completed: 1,
+        requeued: 0,
+      });
+      const [completed] = await db.select().from(commands).where(eq(commands.id, inboxKey));
+      expect(completed.state).toBe("completed");
+      expect(completed.error).toBe("permanent_noop:awaiting_root_commit_expired");
+      expect(await processSlackInbox(replaySlackInboxClaim)).toMatchObject({ claimed: 0 });
+      expect((await postSlack(envelope)).status).toBe(200);
+      const [retried] = await db.select().from(commands).where(eq(commands.id, inboxKey));
+      expect(retried.state).toBe("completed");
+      expect(await processSlackInbox(replaySlackInboxClaim)).toMatchObject({ claimed: 0 });
+    } finally {
+      restartSlackInboxPumpForTest();
+    }
+  });
+
+  test("fails an exhausted stale dispatch left by a crashed process", async () => {
+    stopSlackInboxPumpForTest();
+    const envelope = eventCallback({
+      type: "app_mention",
+      channel: `C${uid("ch")}`,
+      user: "U-HUMAN",
+      text: `<@${BOT}> exhausted crash ${uid("crash")}`,
+      ts: `${uid("ts")}.1`,
+    }) as SlackEnvelope;
+    const inboxKey = slackInboxKey(envelope);
+    try {
+      await persistSlackInboxEvent(envelope);
+      await db
+        .update(commands)
+        .set({
+          state: "dispatched",
+          attemptCount: 8,
+          error: "dead-worker-token",
+          updatedAt: new Date(Date.now() - 31_000),
+        })
+        .where(eq(commands.id, inboxKey));
+      let invoked = false;
+      expect(await processSlackInbox(async () => {
+        invoked = true;
+        return { status: "completed" };
+      })).toMatchObject({ claimed: 0, failed: 1 });
+      expect(invoked).toBe(false);
+      const [row] = await db.select().from(commands).where(eq(commands.id, inboxKey));
+      expect(row).toMatchObject({
+        state: "failed",
+        attemptCount: 8,
+        error: "retry_exhausted_after_restart",
+      });
+    } finally {
+      restartSlackInboxPumpForTest();
+    }
+  });
+
+  test("reply persists before the root INSERT commits, then attaches exactly once", async () => {
+    stopSlackInboxPumpForTest();
+    const marker = uid("root-commit-race");
+    const channel = `C${uid("ch")}`;
+    const rootTs = `${uid("root")}.1`;
+    const replyTs = `${uid("reply")}.2`;
+    const root = eventCallback({
+      type: "app_mention",
+      channel,
+      channel_type: "channel",
+      user: "U-HUMAN",
+      text: `<@${BOT}> race root ${marker}`,
+      ts: rootTs,
+    }) as SlackEnvelope;
+    const reply = eventCallback({
+      type: "message",
+      channel,
+      channel_type: "channel",
+      user: "U-HUMAN",
+      text: `race reply ${marker}`,
+      ts: replyTs,
+      thread_ts: rootTs,
+    }) as SlackEnvelope;
+    let rootReachedInsert!: () => void;
+    const rootInsertBlocked = new Promise<void>((resolve) => { rootReachedInsert = resolve; });
+    let releaseRootInsert!: () => void;
+    const rootInsertRelease = new Promise<void>((resolve) => { releaseRootInsert = resolve; });
+    let rootReleased = false;
+    setSlackInboxBeforePersistInsertForTest(async (envelope) => {
+      if (slackInboxKey(envelope) !== slackInboxKey(root)) return;
+      rootReachedInsert();
+      await rootInsertRelease;
+    });
+    try {
+      const rootRequest = postSlack(root);
+      await rootInsertBlocked;
+
+      const replyResponse = await postSlack(reply);
+      expect(replyResponse.status).toBe(200);
+      const [persistedReply] = await db
+        .select()
+        .from(commands)
+        .where(eq(commands.id, slackInboxKey(reply)));
+      expect(persistedReply).toMatchObject({
+        state: "queued",
+        threadId: slackInboxThreadId(reply),
+      });
+      expect((JSON.parse(persistedReply.payload!) as SlackInboxPayload).defer).toMatchObject({
+        reason: "awaiting_root_commit",
+        count: 0,
+      });
+      const [notYetCommittedRoot] = await db
+        .select({ id: commands.id })
+        .from(commands)
+        .where(eq(commands.id, slackInboxKey(root)));
+      expect(notYetCommittedRoot).toBeUndefined();
+
+      rootReleased = true;
+      releaseRootInsert();
+      expect((await rootRequest).status).toBe(200);
+      const [persistedRoot] = await db
+        .select()
+        .from(commands)
+        .where(eq(commands.id, slackInboxKey(root)));
+      expect(persistedRoot.threadId).toBe(slackInboxThreadId(root));
+
+      restartSlackInboxPumpForTest();
+      const rootRun = await waitFor(async () => findRunByPrompt(`race root ${marker}`));
+      const replyRun = await waitFor(async () => findRunByPrompt(`race reply ${marker}`));
+      expect(replyRun.parent_run_id).toBe(rootRun.id);
+      const { body } = await json<{ runs: any[] }>("/api/runs?all=1");
+      expect(body.runs.filter((run) => run.prompt === `race reply ${marker}`)).toHaveLength(1);
+      const completedReply = await waitFor(async () => {
+        const [row] = await db
+          .select({ state: commands.state })
+          .from(commands)
+          .where(eq(commands.id, slackInboxKey(reply)));
+        return row?.state === "completed" ? row : null;
+      });
+      expect(completedReply.state).toBe("completed");
+    } finally {
+      setSlackInboxBeforePersistInsertForTest(null);
+      if (!rootReleased) releaseRootInsert();
+      restartSlackInboxPumpForTest();
+    }
+  });
+
+  test("Slack root-thread lookup uses the existing commands thread-state index", async () => {
+    stopSlackInboxPumpForTest();
+    const prefix = `slack-plan-${crypto.randomUUID()}`;
+    const targetThread = `${prefix}-target`;
+    try {
+      await db.execute(sql`
+        insert into commands (id, kind, thread_id, state, attempt_count, created_at, updated_at)
+        select
+          ${prefix} || '-' || g::text,
+          ${SLACK_INBOX_EVENT},
+          case when g = 1 then ${targetThread} else ${prefix} || '-thread-' || g::text end,
+          'queued',
+          0,
+          now() - (g * interval '1 millisecond'),
+          now()
+        from generate_series(1, 4000) as g`);
+      await db.execute(sql`analyze commands`);
+      const plan = await db.execute(sql`
+        explain (format text)
+        select id from commands
+        where thread_id = ${targetThread}
+          and state in ('queued', 'dispatched')
+        order by created_at asc
+        limit 1`);
+      const rendered = plan
+        .map((row) => String((row as Record<string, unknown>)["QUERY PLAN"] ?? ""))
+        .join("\n");
+      expect(rendered).toContain("idx_commands_thread_state");
+    } finally {
+      await db.execute(sql`delete from commands where id like ${`${prefix}%`}`);
+      restartSlackInboxPumpForTest();
+    }
+  });
+
+  test("closed root then reply both drain after admission reopens", async () => {
+    stopSlackInboxPumpForTest();
+    const operationId = `slack-root-reply:${crypto.randomUUID()}`;
+    const marker = uid("closed-thread");
+    const channel = `C${uid("ch")}`;
+    const rootTs = `${uid("root")}.1`;
+    const replyTs = `${uid("reply")}.2`;
+    const root = eventCallback({
+      type: "app_mention",
+      channel,
+      user: "U-HUMAN",
+      text: `<@${BOT}> root ${marker}`,
+      ts: rootTs,
+    }) as SlackEnvelope;
+    const reply = eventCallback({
+      type: "message",
+      channel,
+      channel_type: "channel",
+      user: "U-HUMAN",
+      text: `reply ${marker}`,
+      ts: replyTs,
+      thread_ts: rootTs,
+    }) as SlackEnvelope;
+    await setRunAdmission({
+      open: false,
+      operationId,
+      actor: "test",
+      reason: "closed root/reply ordering proof",
+    });
+    try {
+      expect((await postSlack(root)).status).toBe(200);
+      expect((await postSlack(reply)).status).toBe(200);
+      restartSlackInboxPumpForTest();
+      await waitFor(async () => {
+        const rows = await db.select().from(commands).where(sql`${commands.id} in (${slackInboxKey(root)}, ${slackInboxKey(reply)})`);
+        return rows.length === 2 && rows.every((row) => row.state === "queued") ? rows : null;
+      });
+      expect(await findRunByPrompt(`root ${marker}`)).toBeNull();
+      expect(await findRunByPrompt(`reply ${marker}`)).toBeNull();
+      await setRunAdmission({
+        open: true,
+        operationId,
+        actor: "test",
+        reason: "reopen root/reply ordering proof",
+      });
+      const rootRun = await waitFor(async () => findRunByPrompt(`root ${marker}`));
+      const replyRun = await waitFor(async () => findRunByPrompt(`reply ${marker}`));
+      expect(replyRun.parent_run_id).toBe(rootRun.id);
+      expect(replyRun.thread_id).toBe(rootRun.id);
+    } finally {
+      await setRunAdmission({
+        open: true,
+        operationId,
+        actor: "test",
+        reason: "test cleanup",
+      });
+      restartSlackInboxPumpForTest();
+    }
+  });
+
+  test("a reply processed before its pending root waits durably then attaches", async () => {
+    stopSlackInboxPumpForTest();
+    const marker = uid("reverse-thread");
+    const channel = `C${uid("ch")}`;
+    const rootTs = `${uid("root")}.1`;
+    const reply = eventCallback({
+      type: "message",
+      channel,
+      channel_type: "channel",
+      user: "U-HUMAN",
+      text: `reply first ${marker}`,
+      ts: `${uid("reply")}.2`,
+      thread_ts: rootTs,
+    }) as SlackEnvelope;
+    const root = eventCallback({
+      type: "app_mention",
+      channel,
+      user: "U-HUMAN",
+      text: `<@${BOT}> root later ${marker}`,
+      ts: rootTs,
+    }) as SlackEnvelope;
+    try {
+      expect((await postSlack(root)).status).toBe(200);
+      expect((await postSlack(reply)).status).toBe(200);
+      // The root is durably pending, but force the reply to be claimed first.
+      await db
+        .update(commands)
+        .set({ createdAt: new Date(Date.now() - 1_000) })
+        .where(eq(commands.id, slackInboxKey(reply)));
+      restartSlackInboxPumpForTest();
+      const rootRun = await waitFor(async () => findRunByPrompt(`root later ${marker}`));
+      const replyRun = await waitFor(async () => findRunByPrompt(`reply first ${marker}`));
+      expect(replyRun.parent_run_id).toBe(rootRun.id);
+      const replyInbox = await waitFor(async () => {
+        const [row] = await db.select().from(commands).where(eq(commands.id, slackInboxKey(reply)));
+        return row?.state === "completed" ? row : null;
+      });
+      expect(replyInbox.attemptCount).toBe(1);
+    } finally {
+      restartSlackInboxPumpForTest();
+    }
+  });
+
+  test("a healthy claim heartbeat prevents reclaim after more than 30 seconds", async () => {
+    stopSlackInboxPumpForTest();
+    const envelope = eventCallback({
+      type: "app_mention",
+      channel: `C${uid("ch")}`,
+      user: "U-HUMAN",
+      text: `<@${BOT}> long healthy claim ${uid("lease")}`,
+      ts: `${uid("ts")}.1`,
+    }) as SlackEnvelope;
+    try {
+      await persistSlackInboxEvent(envelope);
+      let entered!: () => void;
+      const claimed = new Promise<void>((resolve) => { entered = resolve; });
+      let release!: () => void;
+      const blocked = new Promise<void>((resolve) => { release = resolve; });
+      const firstReplica = processSlackInbox(async (claim) => {
+        await claim.checkpointStagedAttachmentIds(["upload-long-running"]);
+        entered();
+        await blocked;
+        return { status: "completed" };
+      });
+      await claimed;
+      await new Promise((resolve) => setTimeout(resolve, 31_000));
+      expect(await processSlackInbox(async () => ({ status: "completed" }))).toMatchObject({
+        claimed: 0,
+      });
+      const [leased] = await db
+        .select({ payload: commands.payload, state: commands.state })
+        .from(commands)
+        .where(eq(commands.id, slackInboxKey(envelope)));
+      expect(leased.state).toBe("dispatched");
+      expect(leased.payload).toContain("upload-long-running");
+      release();
+      expect(await firstReplica).toMatchObject({ claimed: 1, completed: 1 });
+    } finally {
+      restartSlackInboxPumpForTest();
+    }
+  }, 45_000);
+
+  test("canonical storage drops unknown fields and terminal retention redacts then deletes", async () => {
+    stopSlackInboxPumpForTest();
+    const secret = `provider-secret-${uid("secret")}`;
+    const envelope = {
+      ...eventCallback({
+        type: "app_mention",
+        channel: `C${uid("ch")}`,
+        user: "U-HUMAN",
+        text: `<@${BOT}> retain ${uid("retain")}`,
+        ts: `${uid("ts")}.1`,
+        hidden_provider_field: secret,
+        files: [{
+          id: `F${uid("f")}`,
+          name: "proof.txt",
+          size: 4,
+          mimetype: "text/plain",
+          url_private_download: `https://files.slack.com/${secret}`,
+          hidden_file_field: secret,
+        }],
+      }),
+      hidden_envelope_field: secret,
+    } as SlackEnvelope;
+    const inboxKey = slackInboxKey(envelope);
+    try {
+      await persistSlackInboxEvent(envelope);
+      let [row] = await db.select().from(commands).where(eq(commands.id, inboxKey));
+      expect(row.payload).not.toContain("hidden_provider_field");
+      expect(row.payload).not.toContain("hidden_file_field");
+      expect(row.payload).not.toContain("hidden_envelope_field");
+      expect(row.payload).toContain(secret); // allowlisted file URL is needed until terminal.
+
+      await db
+        .update(commands)
+        .set({ state: "completed", createdAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000) })
+        .where(eq(commands.id, inboxKey));
+      expect(await maintainSlackInboxRetention()).toMatchObject({ redacted: 1 });
+      [row] = await db.select().from(commands).where(eq(commands.id, inboxKey));
+      expect(row.payload).toContain('"redacted"');
+      expect(row.payload).not.toContain(secret);
+
+      await db
+        .update(commands)
+        .set({ createdAt: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000) })
+        .where(eq(commands.id, inboxKey));
+      expect(await maintainSlackInboxRetention()).toMatchObject({ deleted: 1 });
+      const [deleted] = await db.select().from(commands).where(eq(commands.id, inboxKey));
+      expect(deleted).toBeUndefined();
+    } finally {
+      restartSlackInboxPumpForTest();
+    }
+  });
+});
+
 // Durable inbound dedupe: the command lane is keyed by the Slack event identity
 // (slack-event:<team>:<event_id>, channel:ts fallback), so a duplicate that
-// OUTLIVES the in-memory deduper (process restart, cross-lane double delivery)
-// still collapses to one run. resetSlackDeduperForTest simulates the restart.
+// OUTLIVES a process restart or cross-lane double delivery and still collapses
+// to one run through the inbox + run-command identities.
 describe("slack durable inbound dedupe (survives a restart)", () => {
   test("the same event_id re-delivered after a 'restart' does not create a second run", async () => {
     const marker = uid("durable");
@@ -1295,12 +2003,12 @@ describe("slack legacy team adoption", () => {
   });
 });
 
-// Ack-first ingress: the events route 200s immediately after signature
-// verification; processing (staging, acceptance) happens BEHIND the ack.
-describe("slack ack-first ingress", () => {
+// Durable-ack ingress: the events route commits the small inbox row before its
+// 200; slower staging and run acceptance still happen behind that ACK.
+describe("slack durable-ack ingress", () => {
   test("the 200 does not wait for event processing (slow attachment staging)", async () => {
     // A 600ms attachment download would blow a synchronous handler way past
-    // this assertion; ack-first returns while staging is still in flight.
+    // this assertion; durable-ack returns while staging is still in flight.
     setInboundFileDownloaderForTest(async () => {
       await new Promise((r) => setTimeout(r, 600));
       return new TextEncoder().encode("slow bytes");
@@ -1376,9 +2084,9 @@ describe("slack socket-mode ingest shares the HTTP handler", () => {
       eventCallback({ type: "app_mention", channel, user: "U-HUMAN", text: `<@${BOT}> socket ${marker}`, ts }),
     );
 
-    dispatchSocketFrame(raw, (id) => acked.push(id), () => {});
+    await dispatchSocketFrame(raw, (id) => acked.push(id), () => {});
 
-    expect(acked).toEqual([envelopeId]); // acked by envelope_id, before processing
+    expect(acked).toEqual([envelopeId]); // acked after inbox commit, before processing
 
     // Run created via the shared handler, scoped to the dev org.
     const run = await waitFor(async () => findRunByPrompt(`socket ${marker}`));
@@ -1394,11 +2102,29 @@ describe("slack socket-mode ingest shares the HTTP handler", () => {
     expect(answer!.length).toBeGreaterThan(0);
   });
 
-  test("hello is a no-op; disconnect asks us to close", () => {
+  test("a socket event is not ACKed when inbox persistence fails", async () => {
+    const acked: string[] = [];
+    const { raw } = socketFrame(eventCallback({
+      type: "app_mention",
+      channel: `C${uid("ch")}`,
+      user: "U-HUMAN",
+      text: `<@${BOT}> persist failure`,
+      ts: `${uid("ts")}.1`,
+    }));
+    setSlackInboxPersisterForTest(async () => { throw new Error("synthetic inbox outage"); });
+    try {
+      await dispatchSocketFrame(raw, (id) => acked.push(id), () => {});
+      expect(acked).toEqual([]);
+    } finally {
+      setSlackInboxPersisterForTest(null);
+    }
+  });
+
+  test("hello is a no-op; disconnect asks us to close", async () => {
     let closed = 0;
-    dispatchSocketFrame(JSON.stringify({ type: "hello" }), () => {}, () => closed++);
+    await dispatchSocketFrame(JSON.stringify({ type: "hello" }), () => {}, () => closed++);
     expect(closed).toBe(0);
-    dispatchSocketFrame(JSON.stringify({ type: "disconnect" }), () => {}, () => closed++);
+    await dispatchSocketFrame(JSON.stringify({ type: "disconnect" }), () => {}, () => closed++);
     expect(closed).toBe(1);
   });
 });
@@ -1484,21 +2210,25 @@ describe("slack workspace identity (fail closed)", () => {
 
   test("an event from an unmapped workspace is ignored", async () => {
     const marker = uid("noteam");
-    const res = await postSlack(
-      eventCallback(
-        {
-          type: "app_mention",
-          channel: `C${uid("ch")}`,
-          user: "U-HUMAN",
-          text: `<@${BOT}> hi ${marker}`,
-          ts: `${uid("ts")}.1`,
-        },
-        `T-UNMAPPED-${uid("t")}`,
-      ),
-    );
+    const envelope = eventCallback(
+      {
+        type: "app_mention",
+        channel: `C${uid("ch")}`,
+        user: "U-HUMAN",
+        text: `<@${BOT}> hi ${marker}`,
+        ts: `${uid("ts")}.1`,
+      },
+      `T-UNMAPPED-${uid("t")}`,
+    ) as SlackEnvelope;
+    const res = await postSlack(envelope);
     expect(res.status).toBe(200); // acknowledged to Slack...
     await new Promise((r) => setTimeout(r, 150));
     expect(await findRunByPrompt(`hi ${marker}`)).toBeNull(); // ...but no run
+    const inbox = await waitFor(async () => {
+      const [row] = await db.select().from(commands).where(eq(commands.id, slackInboxKey(envelope)));
+      return row?.state === "completed" ? row : null;
+    });
+    expect(inbox.state).toBe("completed");
   });
 
   test("an event carrying no team_id at all is ignored", async () => {
@@ -1608,6 +2338,80 @@ describe("slack inbound attachments", () => {
     expect(upload.sha256).toBe(
       new Bun.CryptoHasher("sha256").update(payload).digest("hex"),
     );
+  });
+
+  test("a close after file staging checkpoints IDs and replay does not redownload", async () => {
+    stopSlackInboxPumpForTest();
+    const operationId = `slack-stage-reclose:${crypto.randomUUID()}`;
+    const marker = uid("reclose");
+    const fileName = `${marker}.txt`;
+    const envelope = eventCallback({
+      type: "app_mention",
+      channel: `C${uid("ch")}`,
+      user: "U-HUMAN",
+      text: `<@${BOT}> summarize ${marker}`,
+      ts: `${uid("ts")}.1`,
+      files: [slackFile(fileName)],
+    }) as SlackEnvelope;
+    const inboxKey = slackInboxKey(envelope);
+    const downloadsBefore = downloaded.length;
+    let closeAfterCheckpoint = true;
+    try {
+      expect((await postSlack(envelope)).status).toBe(200);
+      await db
+        .update(commands)
+        .set({ createdAt: new Date(0) })
+        .where(eq(commands.id, inboxKey));
+      const first = await processSlackInbox(async (claim) => {
+        const identity = await verifySlackInboxIdentity(claim.payload);
+        if (identity.status !== "verified") return { status: "completed" };
+        const outcome = await handleSlackEvent(claim.payload.envelope, {
+          identity,
+          stagedAttachmentIds: claim.payload.stagedAttachmentIds,
+          checkpointStagedAttachmentIds: async (ids) => {
+            await claim.checkpointStagedAttachmentIds(ids);
+            if (closeAfterCheckpoint) {
+              closeAfterCheckpoint = false;
+              await setRunAdmission({
+                open: false,
+                operationId,
+                actor: "test",
+                reason: "close after Slack upload staging",
+              });
+            }
+          },
+        });
+        return outcome.status === "retryable_unavailable"
+          ? { status: "retryable_unavailable", error: outcome.reason }
+          : { status: "completed" };
+      });
+      expect(first.requeued).toBeGreaterThanOrEqual(1);
+      expect(downloaded.length - downloadsBefore).toBe(1);
+      const [queued] = await db.select().from(commands).where(eq(commands.id, inboxKey));
+      expect(queued.state).toBe("queued");
+      expect((JSON.parse(queued.payload!) as { stagedAttachmentIds: string[] }).stagedAttachmentIds).toHaveLength(1);
+
+      await setRunAdmission({
+        open: true,
+        operationId,
+        actor: "test",
+        reason: "reopen after checkpoint proof",
+      });
+      restartSlackInboxPumpForTest();
+      const run = await waitFor(async () => findRunByPrompt(`summarize ${marker}`));
+      expect(run.id).toBeTruthy();
+      expect(downloaded.length - downloadsBefore).toBe(1);
+      const [upload] = await uploadsByName(fileName);
+      expect(upload.runId).toBe(run.id);
+    } finally {
+      await setRunAdmission({
+        open: true,
+        operationId,
+        actor: "test",
+        reason: "test cleanup",
+      });
+      restartSlackInboxPumpForTest();
+    }
   });
 
   test("a files-only DM (file_share subtype, no text) still creates a run", async () => {

--- a/frontend/components/chat/canonical-timeline.nodes.test.ts
+++ b/frontend/components/chat/canonical-timeline.nodes.test.ts
@@ -96,7 +96,7 @@ describe("canonical<->legacy node equivalence (synthetic text / markers / child)
     expect(canon).toEqual(legacy);
   });
 
-  test("durable artifact creation and Slack delivery render identically in both lanes", () => {
+  test("artifact creation and multiple deliveries reconcile into one identical node", () => {
     const descriptor = {
       id: "artifact-1",
       name: "demo.png",
@@ -119,6 +119,20 @@ describe("canonical<->legacy node equivalence (synthetic text / markers / child)
         native: {},
         payload: { ...descriptor, destination: "slack" },
       }),
+      frame({
+        eventType: "artifact.delivered",
+        seq: 2,
+        provider: "skynet",
+        native: {},
+        payload: { ...descriptor, destination: "email" },
+      }),
+      frame({
+        eventType: "artifact.delivered",
+        seq: 3,
+        provider: "skynet",
+        native: {},
+        payload: { ...descriptor, destination: "slack" },
+      }),
     ];
     const { legacy, canon } = bothWays(frames, []);
     expect(legacy).toEqual([
@@ -131,18 +145,67 @@ describe("canonical<->legacy node equivalence (synthetic text / markers / child)
           bytes: 2048,
           sha256: "a".repeat(64),
           contentType: "image/png",
+          destinations: ["email", "slack"],
+        },
+      },
+    ]);
+    expect(canon).toEqual(legacy);
+  });
+
+  test("delivery before creation converges on the creation key and position", () => {
+    const descriptor = {
+      id: "artifact-1",
+      name: "demo.png",
+      size_bytes: 2048,
+      sha256: "a".repeat(64),
+      content_type: "image/png",
+    };
+    const frames: F[] = [
+      frame({
+        eventType: "artifact.delivered",
+        seq: 0,
+        provider: "skynet",
+        native: {},
+        payload: { ...descriptor, destination: "slack" },
+      }),
+      frame({
+        eventType: "artifact.created",
+        seq: 1,
+        provider: "skynet",
+        native: {},
+        payload: { ...descriptor, id: "artifact-2", name: "created-between.png" },
+      }),
+      frame({
+        eventType: "artifact.created",
+        seq: 2,
+        provider: "skynet",
+        native: {},
+        payload: descriptor,
+      }),
+    ];
+    const { legacy, canon } = bothWays(frames, []);
+    expect(legacy).toEqual([
+      {
+        kind: "artifact",
+        key: "e1",
+        artifact: {
+          id: "artifact-2",
+          name: "created-between.png",
+          bytes: 2048,
+          sha256: "a".repeat(64),
+          contentType: "image/png",
         },
       },
       {
         kind: "artifact",
-        key: "e1",
+        key: "e2",
         artifact: {
           id: "artifact-1",
           name: "demo.png",
           bytes: 2048,
           sha256: "a".repeat(64),
           contentType: "image/png",
-          destination: "slack",
+          destinations: ["slack"],
         },
       },
     ]);

--- a/frontend/components/chat/canonical-timeline.ts
+++ b/frontend/components/chat/canonical-timeline.ts
@@ -16,7 +16,14 @@
 // comes from the parts' native ids. Tool detail is still read from the durable step
 // sidecar keyed by identity.nativeEventId (the "bounded raw sidecar").
 
-import { isNarration, parseMarker, type TimelineMarker, type TimelineNode } from "./timeline";
+import {
+  isNarration,
+  parseMarker,
+  reconcileTimelineArtifacts,
+  type TimelineArtifactReceipt,
+  type TimelineMarker,
+  type TimelineNode,
+} from "./timeline";
 import { type ApiStep, deriveTrace, isRenderableTimelineStep } from "./types";
 
 /** Structural view of a canonical event (envelope base + flattened body fields). */
@@ -330,6 +337,37 @@ export function buildTimelineFromCanonical(
   const unpartedText = new Map<string, { text: string; firstSeq: number; order: number }>();
   const unpartedReasoning = new Map<string, { text: string; firstSeq: number }>();
 
+  const artifactReceipts: TimelineArtifactReceipt[] = [];
+  for (const e of ordered) {
+    if (
+      (e.kind !== "artifact.created" && e.kind !== "artifact.delivered") ||
+      !e.artifact ||
+      !e.name
+    )
+      continue;
+    artifactReceipts.push({
+      key: e.identity?.nativeEventId ?? String(e.seq),
+      seq: e.identity?.nativeSeq ?? e.seq,
+      created: e.kind === "artifact.created",
+      artifact: {
+        id: e.artifact.artifactId,
+        name: e.name,
+        bytes: e.artifact.bytes,
+        sha256: e.artifact.sha256,
+        contentType: e.artifact.contentType,
+      },
+      ...(e.kind === "artifact.delivered" && e.destination ? { destination: e.destination } : {}),
+    });
+  }
+  for (const receipt of reconcileTimelineArtifacts(artifactReceipts)) {
+    ranked.push({
+      node: { kind: "artifact", key: receipt.key, artifact: receipt.artifact },
+      k0: MAX,
+      k1: 2,
+      k2: receipt.seq,
+    });
+  }
+
   for (const e of ordered) {
     // ── context markers (useAgent lane): lead the turn ──────────────────────────
     if (e.kind === "context.marker") {
@@ -345,32 +383,7 @@ export function buildTimelineFromCanonical(
       });
       continue;
     }
-    if (
-      (e.kind === "artifact.created" || e.kind === "artifact.delivered") &&
-      e.artifact &&
-      e.name
-    ) {
-      ranked.push({
-        node: {
-          kind: "artifact",
-          key: e.identity?.nativeEventId ?? String(e.seq),
-          artifact: {
-            id: e.artifact.artifactId,
-            name: e.name,
-            bytes: e.artifact.bytes,
-            sha256: e.artifact.sha256,
-            contentType: e.artifact.contentType,
-            ...(e.kind === "artifact.delivered" && e.destination
-              ? { destination: e.destination }
-              : {}),
-          },
-        },
-        k0: MAX,
-        k1: 2,
-        k2: e.identity?.nativeSeq ?? e.seq,
-      });
-      continue;
-    }
+    if (e.kind === "artifact.created" || e.kind === "artifact.delivered") continue;
     // ── assistant text bursts (root, step-messages only; child text -> its pane) ─
     if (e.kind === "message.delta") {
       const sid = e.identity?.nativeSessionId;

--- a/frontend/components/chat/timeline-view.test.tsx
+++ b/frontend/components/chat/timeline-view.test.tsx
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { TimelineNode } from "./timeline";
+import { Timeline } from "./timeline-view";
+
+function renderArtifact(artifact: Extract<TimelineNode, { kind: "artifact" }>["artifact"]): string {
+  return renderToStaticMarkup(
+    <Timeline
+      nodes={[{ kind: "artifact", key: `artifact:${artifact.id}`, artifact }]}
+      live={false}
+    />,
+  );
+}
+
+describe("timeline artifact rendering", () => {
+  test("renders image content inline with expand, preview, download, and delivery badges", () => {
+    const html = renderArtifact({
+      id: "image-1",
+      name: "launch-chart.png",
+      bytes: 2048,
+      sha256: "a".repeat(64),
+      contentType: "image/png",
+      destinations: ["email", "slack"],
+    });
+
+    expect(html).toContain('src="/api/artifacts/image-1/content"');
+    expect(html).toContain('alt="Preview of launch-chart.png"');
+    expect(html).toContain('loading="lazy"');
+    expect(html).toContain('decoding="async"');
+    expect(html).toContain('aria-label="Expand launch-chart.png"');
+    expect(html).toContain('aria-label="Preview launch-chart.png"');
+    expect(html).toContain('href="/api/artifacts/image-1/content"');
+    expect(html).toContain('aria-label="Download launch-chart.png"');
+    expect(html).toContain('href="/api/artifacts/image-1/content?download=1"');
+    expect(html).toContain("Delivered to Email");
+    expect(html).toContain("Delivered to Slack");
+  });
+
+  test("keeps non-image artifacts on the existing file-card action path", () => {
+    const html = renderArtifact({
+      id: "pdf-1",
+      name: "report.pdf",
+      bytes: 4096,
+      sha256: "b".repeat(64),
+      contentType: "application/pdf",
+    });
+
+    expect(html).toContain("report.pdf");
+    expect(html).toContain("Artifact · 4.0 KB");
+    expect(html).toContain('aria-label="Preview report.pdf"');
+    expect(html).toContain('aria-label="Download report.pdf"');
+    expect(html).not.toContain('aria-label="Expand report.pdf"');
+    expect(html).not.toContain("<img");
+  });
+
+  test("keeps active SVG content attachment-only", () => {
+    const html = renderArtifact({
+      id: "svg-1",
+      name: "diagram.svg",
+      bytes: 1024,
+      sha256: "d".repeat(64),
+      contentType: "image/svg+xml",
+    });
+
+    expect(html).toContain("diagram.svg");
+    expect(html).toContain('aria-label="Download diagram.svg"');
+    expect(html).not.toContain('aria-label="Expand diagram.svg"');
+    expect(html).not.toContain("<img");
+  });
+
+  test("legacy single-destination nodes retain content actions", () => {
+    const html = renderArtifact({
+      id: "legacy-1",
+      name: "legacy.png",
+      bytes: 1024,
+      sha256: "c".repeat(64),
+      contentType: "image/png",
+      destination: "slack",
+    });
+
+    expect(html).toContain("Delivered to Slack");
+    expect(html).toContain('src="/api/artifacts/legacy-1/content"');
+    expect(html).toContain('aria-label="Preview legacy.png"');
+    expect(html).toContain('aria-label="Download legacy.png"');
+  });
+});

--- a/frontend/components/chat/timeline-view.tsx
+++ b/frontend/components/chat/timeline-view.tsx
@@ -12,9 +12,12 @@ import {
   RiFileEditLine,
   RiFileLine,
   RiImageLine,
-  RiSlackLine,
 } from "@remixicon/react";
-import { artifactAuthoringProfile, inferWorkpieceKind } from "@useagent/artifact-workspace";
+import {
+  artifactAuthoringProfile,
+  canPreviewInline,
+  inferWorkpieceKind,
+} from "@useagent/artifact-workspace";
 import { memo, useMemo, useState } from "react";
 import { PlanChecklist } from "@/components/agent-ui/plan-checklist";
 import { Thinking } from "@/components/ai/thinking";
@@ -33,10 +36,7 @@ import { MarkerRow } from "@/components/chat/tool-step-row";
 import { basename } from "@/components/chat/types";
 import { useOpenWorkpiece } from "@/components/chat/workspace-open-context";
 import { Markdown } from "@/components/prompt-kit/markdown";
-import {
-  segmentTimeline,
-  type TimelineSegment,
-} from "@/components/session-ui/adapter";
+import { segmentTimeline, type TimelineSegment } from "@/components/session-ui/adapter";
 import {
   ContextRecallFold,
   isContextRecallMarker,
@@ -129,39 +129,104 @@ function ArtifactActions({
   );
 }
 
+function artifactDestinations(artifact: TimelineArtifact): readonly string[] {
+  return [
+    ...new Set([
+      ...(artifact.destinations ?? []),
+      ...(artifact.destination ? [artifact.destination] : []),
+    ]),
+  ].toSorted();
+}
+
+function destinationLabel(destination: string): string {
+  return destination
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(" ");
+}
+
+function ArtifactDeliveryBadges({ destinations }: { destinations: readonly string[] }) {
+  if (destinations.length === 0) return null;
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      {destinations.map((destination) => {
+        const label = destinationLabel(destination);
+        return (
+          <span
+            key={destination}
+            className="rounded-md bg-background-primary-default px-1.5 py-0.5 text-caption-2-medium text-text-tertiary"
+          >
+            Delivered to {label}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
 function ArtifactRow({ node }: { node: Extract<TimelineNode, { kind: "artifact" }> }) {
   const { artifact } = node;
-  const image = artifact.contentType.startsWith("image/");
+  const image = artifact.contentType.startsWith("image/") && canPreviewInline(artifact.contentType);
   const media = image || artifact.contentType.startsWith("video/");
   const Icon = media ? RiImageLine : RiFileLine;
-  // Click-to-expand lightbox for image artifacts with local content (delivered
-  // artifacts have no content endpoint here). Leaf-local state only - no store.
+  const content = `/api/artifacts/${artifact.id}/content`;
+  const destinations = artifactDestinations(artifact);
+  // Click-to-expand state stays local to the image artifact row.
   const [expanded, setExpanded] = useState(false);
-  const expandable = image && !artifact.destination;
-  // A canonical workpiece (document/spreadsheet/deck/pdf, not a delivered copy)
-  // opens IN the session side pane; raw binaries keep card/download. The provider
-  // is null outside a session (the standalone artifacts page), so the card keeps
-  // its plain behavior there.
+  // A canonical workpiece (document/spreadsheet/deck/pdf) opens IN the session
+  // side pane; raw binaries keep card/download. Delivery does not change content.
   const openWorkpiece = useOpenWorkpiece();
-  const workpieceKind =
-    openWorkpiece && !artifact.destination
-      ? inferWorkpieceKind(artifact.name, artifact.contentType, artifact.bytes)
-      : null;
+  const workpieceKind = openWorkpiece
+    ? inferWorkpieceKind(artifact.name, artifact.contentType, artifact.bytes)
+    : null;
   const canOpen = !!openWorkpiece && workpieceKind !== null;
-  const subtitle = artifact.destination
-    ? `Delivered to ${artifact.destination}`
-    : workpieceKind
-      ? `${artifactAuthoringProfile(workpieceKind).label} · ${formatArtifactSize(artifact.bytes)} · Click to open`
-      : `${media ? "Generated media" : "Artifact"} · ${formatArtifactSize(artifact.bytes)}`;
+  const subtitle = workpieceKind
+    ? `${artifactAuthoringProfile(workpieceKind).label} · ${formatArtifactSize(artifact.bytes)} · Click to open`
+    : `${media ? "Generated media" : "Artifact"} · ${formatArtifactSize(artifact.bytes)}`;
   const body = (
     <>
       <Icon aria-hidden className="size-5 shrink-0 text-text-secondary" />
       <div className="min-w-0 flex-1">
         <p className="truncate text-body-2-medium text-text-primary">{artifact.name}</p>
         <p className="text-caption-1-regular text-text-tertiary">{subtitle}</p>
+        <ArtifactDeliveryBadges destinations={destinations} />
       </div>
     </>
   );
+
+  if (image) {
+    return (
+      <div className="min-w-0 overflow-hidden rounded-xl border border-border-button-default bg-background-secondary-default">
+        <button
+          type="button"
+          onClick={() => setExpanded(true)}
+          aria-label={`Expand ${artifact.name}`}
+          className="block w-full cursor-zoom-in bg-background-primary-default outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-border-focus-ring"
+        >
+          {/* biome-ignore lint/performance/noImgElement: authenticated dynamic artifact content is not a Next Image optimization target. */}
+          <img
+            src={content}
+            alt={`Preview of ${artifact.name}`}
+            loading="lazy"
+            decoding="async"
+            className="max-h-96 w-full object-contain"
+          />
+        </button>
+        <div className="flex min-w-0 items-center gap-3 px-3 py-2.5">
+          {body}
+          <ArtifactActions artifact={artifact} />
+        </div>
+        {expanded && (
+          <ExpandedImageDialog
+            preview={{ images: [{ src: content, name: artifact.name }], index: 0 }}
+            onClose={() => setExpanded(false)}
+          />
+        )}
+      </div>
+    );
+  }
+
   return (
     <div
       className={cn(
@@ -178,39 +243,13 @@ function ArtifactRow({ node }: { node: Extract<TimelineNode, { kind: "artifact" 
         >
           {body}
         </button>
-      ) : expandable ? (
-        <button
-          type="button"
-          onClick={() => setExpanded(true)}
-          aria-label={`Expand ${artifact.name}`}
-          className="flex min-w-0 flex-1 cursor-zoom-in items-center gap-3 rounded-lg text-left outline-none focus-visible:ring-2 focus-visible:ring-border-focus-ring"
-        >
-          {body}
-        </button>
       ) : (
         body
       )}
-      {artifact.destination === "slack" && (
-        <RiSlackLine
-          aria-label="Delivered to Slack"
-          className="size-4 shrink-0 text-text-tertiary"
-        />
-      )}
-      {!artifact.destination && (
-        <ArtifactActions
-          artifact={artifact}
-          onOpen={canOpen ? () => openWorkpiece?.(artifact) : undefined}
-        />
-      )}
-      {expanded && (
-        <ExpandedImageDialog
-          preview={{
-            images: [{ src: `/api/artifacts/${artifact.id}/content`, name: artifact.name }],
-            index: 0,
-          }}
-          onClose={() => setExpanded(false)}
-        />
-      )}
+      <ArtifactActions
+        artifact={artifact}
+        onOpen={canOpen ? () => openWorkpiece?.(artifact) : undefined}
+      />
     </div>
   );
 }
@@ -276,12 +315,19 @@ function groupContextRecall(segs: readonly TimelineSegment[]): FlowUnit[] {
       units.push({ kind: "recall", key: `recall-${run[0].key}`, markers: run });
     } else if (run.length === 1) {
       const { key, marker } = run[0];
-      units.push({ kind: "seg", seg: { kind: "node", key, node: { kind: "marker", key, marker } } });
+      units.push({
+        kind: "seg",
+        seg: { kind: "node", key, node: { kind: "marker", key, marker } },
+      });
     }
     run = [];
   };
   for (const seg of segs) {
-    if (seg.kind === "node" && seg.node.kind === "marker" && isContextRecallMarker(seg.node.marker)) {
+    if (
+      seg.kind === "node" &&
+      seg.node.kind === "marker" &&
+      isContextRecallMarker(seg.node.marker)
+    ) {
       run.push({ key: seg.key, marker: seg.node.marker });
     } else {
       flush();
@@ -327,10 +373,7 @@ export function Timeline({
    *  suggestions under scrolled-back history are noise). */
   showFollowups?: boolean;
 }) {
-  const { segments, workingLabel } = useMemo(
-    () => segmentTimeline(nodes, live),
-    [nodes, live],
-  );
+  const { segments, workingLabel } = useMemo(() => segmentTimeline(nodes, live), [nodes, live]);
   // Artifacts are deliverables, not narration: they render AFTER the prose and
   // tool activity so an answer never appears below its own attachment.
   // Follow-ups close the turn after everything else.

--- a/frontend/components/chat/timeline.ts
+++ b/frontend/components/chat/timeline.ts
@@ -68,7 +68,69 @@ export interface TimelineArtifact {
   readonly bytes: number;
   readonly sha256: string;
   readonly contentType: string;
+  /** Delivery receipts enrich the artifact without replacing its content row. */
+  readonly destinations?: readonly string[];
+  /** @deprecated Accept legacy single-destination nodes while callers migrate. */
   readonly destination?: string;
+}
+
+export interface TimelineArtifactReceipt {
+  readonly key: string;
+  readonly seq: number;
+  readonly created: boolean;
+  readonly artifact: TimelineArtifact;
+  readonly destination?: string;
+}
+
+/** Fold an artifact lifecycle into one stable row. Creation owns the row position;
+ * delivery receipts only add deterministic, provider-neutral destinations. */
+export function reconcileTimelineArtifacts(
+  receipts: readonly TimelineArtifactReceipt[],
+): readonly { key: string; seq: number; artifact: TimelineArtifact }[] {
+  const artifacts = new Map<
+    string,
+    {
+      key: string;
+      seq: number;
+      created: boolean;
+      artifact: TimelineArtifact;
+      destinations: Set<string>;
+    }
+  >();
+
+  for (const receipt of receipts) {
+    const current = artifacts.get(receipt.artifact.id);
+    if (!current) {
+      artifacts.set(receipt.artifact.id, {
+        key: receipt.key,
+        seq: receipt.seq,
+        created: receipt.created,
+        artifact: receipt.artifact,
+        destinations: new Set(receipt.destination ? [receipt.destination] : []),
+      });
+      continue;
+    }
+    if (receipt.destination) current.destinations.add(receipt.destination);
+    if (receipt.created && (!current.created || receipt.seq < current.seq)) {
+      current.key = receipt.key;
+      current.seq = receipt.seq;
+      current.created = true;
+      current.artifact = receipt.artifact;
+    } else if (!current.created && receipt.seq < current.seq) {
+      current.key = receipt.key;
+      current.seq = receipt.seq;
+      current.artifact = receipt.artifact;
+    }
+  }
+
+  return [...artifacts.values()].map(({ key, seq, artifact, destinations }) => ({
+    key,
+    seq,
+    artifact: {
+      ...artifact,
+      ...(destinations.size > 0 ? { destinations: [...destinations].toSorted() } : {}),
+    },
+  }));
 }
 
 /** A durable file receipt. The patch body stays out of the event stream; when a
@@ -149,7 +211,10 @@ export function parseFollowups(eventType: string, payload: unknown): readonly st
   return suggestions.length > 0 ? suggestions : null;
 }
 
-function parseArtifact(eventType: string, payload: unknown): TimelineArtifact | null {
+function parseArtifact(
+  eventType: string,
+  payload: unknown,
+): { artifact: TimelineArtifact; destination?: string } | null {
   if (eventType !== "artifact.created" && eventType !== "artifact.delivered") return null;
   const item = asRecord(payload);
   if (
@@ -163,11 +228,13 @@ function parseArtifact(eventType: string, payload: unknown): TimelineArtifact | 
     return null;
   }
   return {
-    id: item.id,
-    name: item.name,
-    bytes: item.size_bytes,
-    sha256: item.sha256,
-    contentType: item.content_type,
+    artifact: {
+      id: item.id,
+      name: item.name,
+      bytes: item.size_bytes,
+      sha256: item.sha256,
+      contentType: item.content_type,
+    },
     ...(eventType === "artifact.delivered" && typeof item.destination === "string"
       ? { destination: item.destination }
       : {}),
@@ -325,17 +392,27 @@ export function buildTimeline(native: NativeSnapshot, live: boolean): TimelineNo
   type Ranked = { node: TimelineNode; k0: number; k1: number; k2: number };
   const ranked: Ranked[] = [];
 
-  // Durable artifact lifecycle rows appear after the turn's narration/tools.
-  // Creation exposes preview/download; delivery is a separate connector receipt.
+  // Durable artifacts appear after the turn's narration/tools. Delivery receipts
+  // enrich the creation row instead of rendering a provider-specific duplicate.
+  const artifactReceipts: TimelineArtifactReceipt[] = [];
   for (const f of nativeFrames) {
     if (f.provider !== "skynet") continue;
-    const artifact = parseArtifact(f.eventType, f.payload);
-    if (!artifact) continue;
+    const parsed = parseArtifact(f.eventType, f.payload);
+    if (!parsed) continue;
+    artifactReceipts.push({
+      key: f.eventId,
+      seq: f.seq,
+      created: f.eventType === "artifact.created",
+      artifact: parsed.artifact,
+      ...(parsed.destination ? { destination: parsed.destination } : {}),
+    });
+  }
+  for (const receipt of reconcileTimelineArtifacts(artifactReceipts)) {
     ranked.push({
-      node: { kind: "artifact", key: f.eventId, artifact },
+      node: { kind: "artifact", key: receipt.key, artifact: receipt.artifact },
       k0: Number.MAX_SAFE_INTEGER,
       k1: 2,
-      k2: f.seq,
+      k2: receipt.seq,
     });
   }
 


### PR DESCRIPTION
History-rewrite restoration
These reviewed Slack follow-ups remained in Pro but were no longer present in current OSS main:
- durable replayable Slack ingress and quiescent pump lifecycle
- correct Slack chat.appendStream/chat.stopStream ts field
- unified inline image artifacts and delivery-destination reconciliation

Verification
- Root TypeScript: clean.
- Slack native stream and durable inbox focused suite: 70/72 in a repeated shared DB; the two isolation-sensitive cases each pass on a freshly recreated database.
- Timeline/canonical artifact UI: 37/37.
- Diff check: clean.

No Pro-only or private deployment tooling is included.