### PR TITLE
Allow long silent reasoning windows

### DIFF
--- a/backend/src/engines/runtime-environment.test.ts
+++ b/backend/src/engines/runtime-environment.test.ts
@@ -72,10 +72,10 @@ describe("T3 Cube environment", () => {
   });
 
   test("bounds provider no-progress time with an operator-tunable timeout", () => {
-    expect(runtimeNoProgressTimeoutMs({})).toBe(120_000);
+    expect(runtimeNoProgressTimeoutMs({})).toBe(600_000);
     expect(runtimeNoProgressTimeoutMs({ T3_NO_PROGRESS_TIMEOUT_MS: "2500" })).toBe(2500);
-    expect(runtimeNoProgressTimeoutMs({ T3_NO_PROGRESS_TIMEOUT_MS: "0" })).toBe(120_000);
-    expect(runtimeNoProgressTimeoutMs({ T3_NO_PROGRESS_TIMEOUT_MS: "nah" })).toBe(120_000);
+    expect(runtimeNoProgressTimeoutMs({ T3_NO_PROGRESS_TIMEOUT_MS: "0" })).toBe(600_000);
+    expect(runtimeNoProgressTimeoutMs({ T3_NO_PROGRESS_TIMEOUT_MS: "nah" })).toBe(600_000);
     expect(runtimeNoProgressTimeoutMs({ RUNTIME_NO_PROGRESS_TIMEOUT_MS: "3500" })).toBe(3500);
   });
 

--- a/backend/src/engines/runtime-environment.ts
+++ b/backend/src/engines/runtime-environment.ts
@@ -24,7 +24,7 @@ const RUNTIME_READINESS_DEADLINE_MS = 60_000;
 const RUNTIME_READINESS_DELAY_MS = 100;
 const RUNTIME_STOP_DEADLINE_MS = 15_000;
 const DEFAULT_FIRST_ACTIVITY_TIMEOUT_MS = 45_000;
-const DEFAULT_NO_PROGRESS_TIMEOUT_MS = 120_000;
+const DEFAULT_NO_PROGRESS_TIMEOUT_MS = 600_000;
 type TimingRecorder = Pick<RunStageTimer, "begin">;
 type RuntimeEnvironmentSandbox = Pick<SandboxHandle, "id"> & {
   readonly process: Pick<

--- a/backend/src/engines/turn-no-progress.test.ts
+++ b/backend/src/engines/turn-no-progress.test.ts
@@ -121,7 +121,9 @@ describe("T3 no-progress watchdog", () => {
       );
       const reason = await abortReason(watchdog.signal);
       expect(reason).toBeInstanceOf(NoProgressError);
-      expect((reason as Error).message).toContain("retry warnings in 20ms");
+      expect((reason as Error).message).toContain(
+        "20ms without provider activity; retry warnings=1",
+      );
       expect((reason as Error).message).toContain(
         "retry attempt 3: Internal Server Error: Internal Server Error",
       );

--- a/backend/src/engines/turn-no-progress.ts
+++ b/backend/src/engines/turn-no-progress.ts
@@ -72,7 +72,7 @@ export function createNoProgressWatchdog(
     clearTimeout(timer);
     timer = setTimeout(() => {
       const error = noProgressError(
-        `${consecutiveRetryWarnings} retry warnings in ${timeoutMs}ms`,
+        `${timeoutMs}ms without provider activity; retry warnings=${consecutiveRetryWarnings}`,
       );
       settle();
       controller.abort(error);


### PR DESCRIPTION
Syncs the deployed Pro watchdog calibration.

- Silent-provider no-progress default: 2 minutes to 10 minutes.
- Long tools still heartbeat indefinitely.
- Eight consecutive retry warnings still fail early.
- Outer inactivity, operator override, and four-hour absolute ceiling remain.
- Error text now distinguishes provider silence from retry warnings.

Verification: 42/42 focused runtime tests and backend TypeScript clean.
Deployed Pro commit: f7f4c90141ca68cd0f82b950d6c8f502d105be80.