### PR TITLE
sync: deliver revised artifacts to linked channels

### DIFF
--- a/backend/src/artifacts/publish.ts
+++ b/backend/src/artifacts/publish.ts
@@ -24,7 +24,6 @@ import { artifactStorage } from "./storage";
 import { getRunForOrg } from "../runs/repo";
 import { publishOrgChange } from "../runs/org-signals";
 import {
-  recordProviderEvent,
   recordProviderEventIfAbsent,
 } from "../runs/provider-events";
 import { materializeFinishedWorkArtifactIfActive } from "../runs/finished-work-materialization-context";
@@ -415,17 +414,14 @@ export async function publishSandboxArtifact(input: {
       { regenerate: true },
     );
     const descriptor = toArtifactDescriptor(revisedWithPreview);
-    await recordProviderEvent(
-      {
-        id: `artifact.revised:${revisedWithPreview.id}:${revisedWithPreview.workpieceRevision}`,
-        runId: run.id,
-        threadId: run.threadId,
-        provider: "skynet",
-        eventType: "artifact.revised",
-        payload: descriptor,
-      },
-      { critical: true },
-    );
+    await recordProviderEventIfAbsent({
+      id: `artifact.revised:${revisedWithPreview.id}:${revisedWithPreview.workpieceRevision}`,
+      runId: run.id,
+      threadId: run.threadId,
+      provider: "skynet",
+      eventType: "artifact.revised",
+      payload: descriptor,
+    });
     publishOrgChange(input.orgId, {
       type: "artifact",
       action: "updated",
@@ -480,17 +476,14 @@ export async function publishSandboxArtifact(input: {
     { regenerate: false },
   );
   const descriptor = toArtifactDescriptor(record);
-  await recordProviderEvent(
-    {
-      id: `artifact.created:${record.id}`,
-      runId: run.id,
-      threadId: run.threadId,
-      provider: "skynet",
-      eventType: "artifact.created",
-      payload: descriptor,
-    },
-    { critical: true },
-  );
+  await recordProviderEventIfAbsent({
+    id: `artifact.created:${record.id}`,
+    runId: run.id,
+    threadId: run.threadId,
+    provider: "skynet",
+    eventType: "artifact.created",
+    payload: descriptor,
+  });
   if (stored.created) {
     publishOrgChange(input.orgId, {
       type: "artifact",

--- a/backend/test/gateway-finished-work-role.test.ts
+++ b/backend/test/gateway-finished-work-role.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { eq, sql } from "drizzle-orm";
+import { eq, inArray, sql } from "drizzle-orm";
 import { createArtifactRecord } from "../src/artifacts/repo";
 import { db } from "../src/db/client";
-import { finishedWorkObligations, finishedWorkReceipts } from "../src/db/schema";
+import {
+  finishedWorkObligations,
+  finishedWorkReceipts,
+  providerEvents,
+} from "../src/db/schema";
 import { createRun } from "../src/runs/repo";
 import "./helpers";
 
@@ -108,5 +112,77 @@ describe("restricted gateway FinishedWork grants", () => {
         .set({ sourceKey: `${sourceKey}:changed` })
         .where(eq(finishedWorkObligations.id, ids.obligationId));
     })).rejects.toThrow();
+  });
+
+  test("artifact_publish create and revision events stay immutable under the restricted role", async () => {
+    const roles = await db.execute(sql`
+      select rolname from pg_roles
+      where rolname in ('useagent_gateway', 'skynet_gateway')
+      order by (rolname = 'useagent_gateway') desc
+      limit 1
+    `);
+    const role = roles[0]?.rolname;
+    if (typeof role !== "string") return;
+
+    {
+      const runId = crypto.randomUUID();
+      await createRun({
+        id: runId,
+        prompt: "restricted artifact_publish proof",
+        model: "test",
+        engine: "mock",
+        orgId: ORG,
+        userId: null,
+        parentRunId: null,
+        threadId: runId,
+        repos: [],
+        memoryScope: "org",
+      });
+
+      const artifactId = crypto.randomUUID();
+      const createdId = `artifact.created:${artifactId}`;
+      const revisedId = `artifact.revised:${artifactId}:1`;
+      const insert = async (
+        tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
+        id: string,
+        eventType: "artifact.created" | "artifact.revised",
+        seq: number,
+        sha256: string,
+      ) => tx.insert(providerEvents).values({
+        id,
+        runId,
+        threadId: runId,
+        seq,
+        provider: "skynet",
+        eventType,
+        payload: JSON.stringify({ id: artifactId, sha256 }),
+      }).onConflictDoNothing({ target: providerEvents.id }).returning({ id: providerEvents.id });
+
+      const inserted = await db.transaction(async (tx) => {
+        await tx.execute(sql.raw(`set local role "${role}"`));
+        return [
+          await insert(tx, createdId, "artifact.created", 0, "a".repeat(64)),
+          await insert(tx, revisedId, "artifact.revised", 1, "b".repeat(64)),
+          await insert(tx, createdId, "artifact.created", 2, "f".repeat(64)),
+          await insert(tx, revisedId, "artifact.revised", 3, "f".repeat(64)),
+        ];
+      });
+
+      expect(inserted.map((rows) => rows.length)).toEqual([1, 1, 0, 0]);
+      const events = await db.select({ id: providerEvents.id, payload: providerEvents.payload })
+        .from(providerEvents)
+        .where(inArray(providerEvents.id, [createdId, revisedId]));
+      expect(events.map(({ id, payload }) => [id, JSON.parse(payload ?? "{}").sha256])).toEqual([
+        [createdId, "a".repeat(64)],
+        [revisedId, "b".repeat(64)],
+      ]);
+
+      await expect(db.transaction(async (tx) => {
+        await tx.execute(sql.raw(`set local role "${role}"`));
+        await tx.update(providerEvents)
+          .set({ provider: "forged" })
+          .where(eq(providerEvents.id, revisedId));
+      })).rejects.toThrow();
+    }
   });
 });

--- a/backend/test/slack-reply-durability.test.ts
+++ b/backend/test/slack-reply-durability.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { eq, like, sql } from "drizzle-orm";
+import { and, eq, like, sql } from "drizzle-orm";
 import { db } from "../src/db/client";
 import { artifacts, providerEvents, slackOutbox, slackThreads } from "../src/db/schema";
 import { acceptRunCommand } from "../src/commands";
 import { finalizeRun } from "../src/runs/finalize";
 import { recoverStaleRuns, type ReconcileProbe } from "../src/runs/recovery";
-import { recordProviderEvent } from "../src/runs/provider-events";
+import { recordProviderEvent, recordProviderEventIfAbsent } from "../src/runs/provider-events";
 import {
   createSlackRunResponse,
   findSlackThreadByRoot,
@@ -193,12 +193,22 @@ describe("slack reply durability at finalization (GAP 3)", () => {
     await db.update(artifacts).set({
       sha256: "c".repeat(64), storageKey: `test/${revisionRunId}/report-v2.pdf`, workpieceRevision: 1,
     }).where(eq(artifacts.id, artifact.id));
-    await db.insert(providerEvents).values({
-      id: `artifact.revised:${artifact.id}:1`, runId: revisionRunId, threadId: root.runId,
-      seq: 1, provider: "skynet", eventType: "artifact.revised", payload: JSON.stringify({ id: artifact.id }),
-    });
+    const revisionEvent = {
+      id: `artifact.revised:${artifact.id}:1`,
+      runId: revisionRunId,
+      threadId: root.runId,
+      provider: "skynet",
+      eventType: "artifact.revised",
+      payload: { id: artifact.id, sha256: "c".repeat(64), workpiece: { state_revision: 1 } },
+    } as const;
+    expect(await recordProviderEventIfAbsent(revisionEvent)).toBe(true);
+    expect(await recordProviderEventIfAbsent({
+      ...revisionEvent,
+      payload: { id: artifact.id, sha256: "d".repeat(64), workpiece: { state_revision: 99 } },
+    })).toBe(false);
     await finalizeRun(revisionRunId, "completed", "revised web follow-up finished", 100);
-    expect(await getSlackOutbox(slackArtifactDeliveryIdempotencyKey({
+    await finalizeRun(revisionRunId, "completed", "revised web follow-up finished", 100);
+    const revisionUploadKey = slackArtifactDeliveryIdempotencyKey({
       teamId: TEAM,
       runId: revisionRunId,
       artifactId: artifact.id,
@@ -206,7 +216,31 @@ describe("slack reply durability at finalization (GAP 3)", () => {
       artifactSha256: "c".repeat(64),
       channel: root.channel,
       threadTs: root.ts,
-    }))).not.toBeNull();
+    });
+    const revisionUpload = await getSlackOutbox(revisionUploadKey);
+    expect(JSON.parse(revisionUpload?.payload ?? "{}")).toMatchObject({
+      artifactId: artifact.id,
+      artifactRevision: 1,
+      artifactSha256: "c".repeat(64),
+      artifactStorageKey: `test/${revisionRunId}/report-v2.pdf`,
+      deliveryRunId: revisionRunId,
+    });
+    const revisionEvents = await db.select({ payload: providerEvents.payload })
+      .from(providerEvents)
+      .where(and(
+        eq(providerEvents.runId, revisionRunId),
+        eq(providerEvents.eventType, "artifact.revised"),
+      ));
+    expect(revisionEvents).toHaveLength(1);
+    expect(JSON.parse(revisionEvents[0]?.payload ?? "{}")).toMatchObject({
+      id: artifact.id,
+      sha256: "c".repeat(64),
+      workpiece: { state_revision: 1 },
+    });
+    const revisionUploads = await db.select({ id: slackOutbox.id })
+      .from(slackOutbox)
+      .where(eq(slackOutbox.idempotencyKey, revisionUploadKey));
+    expect(revisionUploads).toHaveLength(1);
   });
 
   test("reply enqueue is idempotent across re-finalization (crash-retry safe)", async () => {


### PR DESCRIPTION
Syncs the reviewed immutable artifact lifecycle-event fix so revised stable artifacts are discovered and delivered to linked Slack threads without widening gateway grants.

Verification: guard 3 paths; root typecheck; targeted 10 tests / 37 assertions; staged gitleaks and diff-check; independent review APPROVE; exact byte parity with Pro merge 65462bd4.